### PR TITLE
Support Flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = F401, F403
+max-line-length = 120
+exclude =
+    .git,
+    __pycache__,

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ The config file is saved in the same folder.
 ## Contributing
 Feel free to contribute any kind of function or enhancement, here the coding style follows PEP8
 
+Code should pass the [Flake8](http://flake8.pycqa.org/en/latest/) check before committing.
+
 ## TODOs
 - [ ] Multi-GPU support
 - [ ] `TensorboardX` or `visdom` support

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ PyTorch deep learning project made easy.
 The code in this repo is an MNIST example of the template.
 
 ### Config file format
-Config files are in ```.json``` format:
+Config files are in `.json` format:
   ```
   {
     "name": "Mnist_LeNet",        // training session name
@@ -122,7 +122,7 @@ Config files are in ```.json``` format:
 Add addional configurations if you need.
 
 ### Using config files
-Modify the configurations in ```.json``` config files, then run:
+Modify the configurations in `.json` config files, then run:
 
   ```
   python train.py --config config.json
@@ -141,72 +141,72 @@ You can resume from a previously saved checkpoint by:
 
 1. **Inherit ```BaseDataLoader```**
 
-    ```BaseDataLoader``` is similar to ```torch.utils.data.DataLoader```, you can use either of them.
+    `BaseDataLoader` is similar to `torch.utils.data.DataLoader`, you can use either of them.
 
-    ```BaseDataLoader``` handles:
+    `BaseDataLoader` handles:
     * Generating next batch
     * Data shuffling
     * Generating validation data loader by calling
-    ```BaseDataLoader.split_validation()```
+    `BaseDataLoader.split_validation()`
 
 2. **Implementing abstract methods**
 
     **You need to implement these abstract methods:**
-    * ```_pack_data()```: pack data members into a list of tuples
-    * ```_unpack_data()```: unpack packed data
-    * ```_update_data()```: updata data members
-    * ```_n_samples()```: total number of samples
+    * `_pack_data()`: pack data members into a list of tuples
+    * `_unpack_data()`: unpack packed data
+    * `_update_data()`: updata data members
+    * `_n_samples()`: total number of samples
 
 * **DataLoader Usage**
 
-  ```BaseDataLoader``` is an iterator, to iterate through batches:
+  `BaseDataLoader` is an iterator, to iterate through batches:
   ```python
   for batch_idx, (x_batch, y_batch) in data_loader:
       pass
   ```
 * **Example**
 
-  Please refer to ```data_loader/data_loaders.py``` for an MNIST data loading example.
+  Please refer to `data_loader/data_loaders.py` for an MNIST data loading example.
 
 ### Trainer
 * **Writing your own trainer**
 
 1. **Inherit ```BaseTrainer```**
 
-    ```BaseTrainer``` handles:
+    `BaseTrainer` handles:
     * Training process logging
     * Checkpoint saving
     * Checkpoint resuming
     * Reconfigurable monitored value for saving current best
-      * Controlled by the configs ```monitor``` and ```monitor_mode```, if ```monitor_mode == 'min'``` then the trainer will save a checkpoint ```model_best.pth.tar``` when ```monitor``` is a current minimum
+      * Controlled by the configs `monitor` and `monitor_mode`, if `monitor_mode == 'min'` then the trainer will save a checkpoint `model_best.pth.tar` when `monitor` is a current minimum
 
 2. **Implementing abstract methods**
 
-    You need to implement ```_train_epoch()``` for your training process, if you need validation then you can implement ```_valid_epoch()``` as in ```trainer/trainer.py```
+    You need to implement `_train_epoch()` for your training process, if you need validation then you can implement `_valid_epoch()` as in `trainer/trainer.py`
 
 * **Example**
 
-  Please refer to ```trainer/trainer.py``` for MNIST training.
+  Please refer to `trainer/trainer.py` for MNIST training.
 
 ### Model
 * **Writing your own model**
 
-1. **Inherit ```BaseModel```**
+1. **Inherit `BaseModel`**
 
-    ```BaseModel``` handles:
-    * Inherited from ```torch.nn.Module```
-    * ```summary()```: Model summary
+    `BaseModel` handles:
+    * Inherited from `torch.nn.Module`
+    * `summary()`: Model summary
 
 2. **Implementing abstract methods**
 
-    Implement the foward pass method ```forward()```
+    Implement the foward pass method `forward()`
 
 * **Example**
 
-  Please refer to ```model/model.py``` for a LeNet example.
+  Please refer to `model/model.py` for a LeNet example.
 
 ### Loss and metrics
-If you need to change the loss function or metrics, first ```import``` those function in ```train.py```, then modify ```"loss"``` and ```"metrics"``` in ```.json``` config files
+If you need to change the loss function or metrics, first `import` those function in `train.py`, then modify `"loss"` and `"metrics"` in `.json` config files
 
 #### Multiple metrics
 You can add multiple metrics in your config files:
@@ -215,7 +215,7 @@ You can add multiple metrics in your config files:
   ```
 
 ### Additional logging
-If you have additional information to be logged, in ```_train_epoch()``` of your trainer class, merge them with ```log``` as shown below before returning:
+If you have additional information to be logged, in `_train_epoch()` of your trainer class, merge them with `log` as shown below before returning:
 
   ```python
   additional_log = {"gradient_norm": g, "sensitivity": s}
@@ -224,10 +224,10 @@ If you have additional information to be logged, in ```_train_epoch()``` of your
   ```
 
 ### Validation data
-To split validation data from a data loader, call ```BaseDataLoader.split_validation()```, it will return a validation data loader, with the number of samples according to the specified ratio in your config file.
+To split validation data from a data loader, call `BaseDataLoader.split_validation()`, it will return a validation data loader, with the number of samples according to the specified ratio in your config file.
 
-**Note**: the ```split_validation()``` method will modify the original data loader
-**Note**: ```split_validation()``` will return ```None``` if ```"validation_split"``` is set to `0`
+**Note**: the `split_validation()` method will modify the original data loader
+**Note**: `split_validation()` will return `None` if `"validation_split"` is set to `0`
 
 ### Checkpoints
 You can specify the name of the training session in config files:
@@ -235,7 +235,7 @@ You can specify the name of the training session in config files:
   "name": "MNIST_LeNet",
   ```
 
-The checkpoints will be saved in ```save_dir/name```.
+The checkpoints will be saved in `save_dir/name`.
 
 The config file is saved in the same folder.
 

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -25,6 +25,9 @@ class BaseTrainer:
         if config['cuda'] and not torch.cuda.is_available():
             self.logger.warning('Warning: There\'s no CUDA support on this machine, '
                                 'training is performed on CPU.')
+        else:
+            self.gpu = 'cuda:' + str(config['gpu'])
+
         self.train_logger = train_logger
         self.optimizer = getattr(optim, config['optimizer_type'])(model.parameters(),
                                                                   **config['optimizer'])

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -28,13 +28,13 @@ class BaseTrainer:
         else:
             self.gpu = torch.device('cuda:' + str(config['gpu']))
             self.model = self.model.to(self.gpu)
-            
 
         self.train_logger = train_logger
         self.optimizer = getattr(optim, config['optimizer_type'])(model.parameters(),
                                                                   **config['optimizer'])
-        self.lr_scheduler = getattr(optim.lr_scheduler,
-                config['lr_scheduler_type'], None)
+        self.lr_scheduler = getattr(
+            optim.lr_scheduler,
+            config['lr_scheduler_type'], None)
         if self.lr_scheduler:
             self.lr_scheduler = self.lr_scheduler(self.optimizer, **config['lr_scheduler'])
             self.lr_scheduler_freq = config['lr_scheduler_freq']
@@ -54,7 +54,7 @@ class BaseTrainer:
         """
         Full training logic
         """
-        for epoch in range(self.start_epoch, self.epochs+1):
+        for epoch in range(self.start_epoch, self.epochs + 1):
             result = self._train_epoch(epoch)
             log = {'epoch': epoch}
             for key, value in result.items():
@@ -77,7 +77,7 @@ class BaseTrainer:
                 self._save_checkpoint(epoch, log, save_best=True)
             if epoch % self.save_freq == 0:
                 self._save_checkpoint(epoch, log)
-            if self.lr_scheduler and  epoch % self.lr_scheduler_freq == 0:
+            if self.lr_scheduler and epoch % self.lr_scheduler_freq == 0:
                 self.lr_scheduler.step(epoch)
                 lr = self.lr_scheduler.get_lr()[0]
                 self.logger.info('New Learning Rate: {:.6f}'.format(lr))

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -26,12 +26,18 @@ class BaseTrainer:
             self.logger.warning('Warning: There\'s no CUDA support on this machine, '
                                 'training is performed on CPU.')
         else:
-            self.gpu = 'cuda:' + str(config['gpu'])
+            self.gpu = torch.device('cuda:' + str(config['gpu']))
+            self.model = self.model.to(self.gpu)
+            
 
         self.train_logger = train_logger
         self.optimizer = getattr(optim, config['optimizer_type'])(model.parameters(),
                                                                   **config['optimizer'])
-        self.lr_scheduler = getattr(optim.lr_scheduler, config['lr_scheduler_type'])(self.optimizer, **config['lr_scheduler'])
+        self.lr_scheduler = getattr(optim.lr_scheduler,
+                config['lr_scheduler_type'], None)
+        if self.lr_scheduler:
+            self.lr_scheduler = self.lr_scheduler(self.optimizer, **config['lr_scheduler'])
+            self.lr_scheduler_freq = config['lr_scheduler_freq']
         self.monitor = config['trainer']['monitor']
         self.monitor_mode = config['trainer']['monitor_mode']
         assert self.monitor_mode == 'min' or self.monitor_mode == 'max'
@@ -71,6 +77,10 @@ class BaseTrainer:
                 self._save_checkpoint(epoch, log, save_best=True)
             if epoch % self.save_freq == 0:
                 self._save_checkpoint(epoch, log)
+            if self.lr_scheduler and  epoch % self.lr_scheduler_freq == 0:
+                self.lr_scheduler.step(epoch)
+                lr = self.lr_scheduler.get_lr()[0]
+                self.logger.info('New Learning Rate: {:.6f}'.format(lr))
 
     def _train_epoch(self, epoch):
         """

--- a/config.json
+++ b/config.json
@@ -11,6 +11,12 @@
         "validation_split": 0.1,
         "shuffle": true
     },
+
+    "lr_scheduler_type": "ExponentialLR",
+    "lr_scheduler": {
+            "gamma": 0.8685113737513527
+    },
+ 
     "optimizer_type": "Adam",
     "optimizer": {
         "lr": 0.001,

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
     },
 
     "lr_scheduler_type": "ExponentialLR",
+    "lr_scheduler_freq": 1,
     "lr_scheduler": {
             "gamma": 0.8685113737513527
     },

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "Mnist_LeNet",
     "cuda": true,
+    "gpu": 0,
     "data_loader": {
         "data_dir": "datasets/",
         "batch_size": 32,

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1,6 +1,5 @@
 import numpy as np
 import torch
-from torch.autograd import Variable
 from base import BaseTrainer
 
 
@@ -22,11 +21,10 @@ class Trainer(BaseTrainer):
         self.valid = True if self.valid_data_loader is not None else False
         self.log_step = int(np.sqrt(self.batch_size))
 
-    def _to_variable(self, data, target):
+    def _to_tensor(self, data, target):
         data, target = torch.FloatTensor(data), torch.LongTensor(target)
-        data, target = Variable(data), Variable(target)
         if self.with_cuda:
-            data, target = data.cuda(), target.cuda()
+            data, target = data.to(self.gpu), target.to(self.gpu)
         return data, target
 
     def _eval_metrics(self, output, target):
@@ -61,7 +59,7 @@ class Trainer(BaseTrainer):
         total_loss = 0
         total_metrics = np.zeros(len(self.metrics))
         for batch_idx, (data, target) in enumerate(self.data_loader):
-            data, target = self._to_variable(data, target)
+            data, target = self._to_tensor(data, target)
 
             self.optimizer.zero_grad()
             output = self.model(data)
@@ -104,7 +102,7 @@ class Trainer(BaseTrainer):
         total_val_loss = 0
         total_val_metrics = np.zeros(len(self.metrics))
         for batch_idx, (data, target) in enumerate(self.valid_data_loader):
-            data, target = self._to_variable(data, target)
+            data, target = self._to_tensor(data, target)
 
             output = self.model(data)
             loss = self.loss(output, target)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -70,22 +70,20 @@ class Trainer(BaseTrainer):
 
             if self.verbosity >= 2 and batch_idx % self.log_step == 0:
                 self.logger.info('Train Epoch: {} [{}/{} ({:.0f}%)] Loss: {:.6f}'.format(
-                    epoch, 
+                    epoch,
                     batch_idx * self.data_loader.batch_size,
                     len(self.data_loader) * self.data_loader.batch_size,
-                    100.0 * batch_idx / len(self.data_loader), 
+                    100.0 * batch_idx / len(self.data_loader),
                     loss.item()))
 
         log = {
-            'loss': total_loss / len(self.data_loader), 
+            'loss': total_loss / len(self.data_loader),
             'metrics': (total_metrics / len(self.data_loader)).tolist()
         }
 
         if self.valid:
             val_log = self._valid_epoch()
             log = {**log, **val_log}
-
-
 
         return log
 
@@ -112,6 +110,6 @@ class Trainer(BaseTrainer):
                 total_val_metrics += self._eval_metrics(output, target)
 
         return {
-            'val_loss': total_val_loss / len(self.valid_data_loader), 
+            'val_loss': total_val_loss / len(self.valid_data_loader),
             'val_metrics': (total_val_metrics / len(self.valid_data_loader)).tolist()
         }


### PR DESCRIPTION
This PR aims to fix Flake8 errors.

Flake8 (http://flake8.pycqa.org/en/latest/) is a very popular and useful checker for Python. It is “the wrapper which verifies pep8, pyflakes and circular complexity “. The code could be checked by the command `flake .`. Personally, I recommend using the ALE plugin (https://github.com/w0rp/ale) for VIM. There are plugins for Subline as well.

Changes:

* Add a .flake8 file to ignore F401 and F403: these two errors are caused by `from module import *`, but in this template we use eval(config) to initialize models, so they are ignored.
* Fix extra-whitespace errors
* Update readme

By the way, I'm NTUEE b04 :)
It's a very good project! I'm willing to help you maintain and develop.

Allen