### PR TITLE
Split validation without packing full data into a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,111 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.idea/
-saved/
-data/
-datasets/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+# vscode cache
+.vscode
+.vs
+
+Experiments.ipynb
+Untitled.ipynb
+
+

--- a/base/base_data_loader.py
+++ b/base/base_data_loader.py
@@ -8,12 +8,13 @@ class BaseDataLoader(DataLoader):
     """
     Base class for all data loaders
     """
-    def __init__(self, dataset, batch_size, shuffle, validation_split, validation_fold, num_workers, collate_fn=default_collate):
+    def __init__(self, dataset, batch_size, valid_batch_size, shuffle, validation_split, validation_fold, num_workers, collate_fn=default_collate):
         """
         :param batch_size: Mini-batch size
         """
         self.dataset = dataset
         self.batch_size = batch_size
+        self.valid_batch_size = valid_batch_size
         self.shuffle = shuffle
         self._n_samples = len(self.dataset)
         self.num_workers = num_workers
@@ -26,12 +27,11 @@ class BaseDataLoader(DataLoader):
 
         self.init_kwargs = {
             'dataset': self.dataset,
-            'batch_size': self.batch_size,
             'num_workers': self.num_workers,
             'shuffle': self.shuffle,
             'collate_fn': self.collate_fn
             }
-        super(BaseDataLoader, self).__init__(**self.init_kwargs, sampler=self.sampler)
+        super(BaseDataLoader, self).__init__(**self.init_kwargs, sampler=self.sampler, batch_size=self.batch_size)
 
     def __len__(self):
         """
@@ -65,5 +65,5 @@ class BaseDataLoader(DataLoader):
         if self.valid_sampler is None:
             return None
         else:
-            valid_loader = DataLoader(**self.init_kwargs, sampler=self.valid_sampler)
+            valid_loader = DataLoader(**self.init_kwargs, sampler=self.valid_sampler, batch_size=self.valid_batch_size)
             return valid_loader

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -11,7 +11,7 @@ class BaseTrainer:
     """
     def __init__(self, model, loss, metrics, optimizer, epochs,
                  save_dir, save_freq, resume, verbosity, training_name,
-                 with_cuda, train_logger=None, monitor='loss', monitor_mode='min'):
+                 train_logger=None, monitor='loss', monitor_mode='min'):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.model = model
         self.loss = loss
@@ -22,10 +22,7 @@ class BaseTrainer:
         self.verbosity = verbosity
         self.training_name = training_name
         self.train_logger = train_logger
-        self.with_cuda = with_cuda and torch.cuda.is_available()
-        if with_cuda and not torch.cuda.is_available():
-            self.logger.warning('Warning: There\'s no CUDA support on this machine, '
-                                'training is performed on CPU.')
+        # self.device = device
         self.monitor = monitor
         self.monitor_mode = monitor_mode
         assert monitor_mode == 'min' or monitor_mode == 'max'

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -10,7 +10,7 @@ class BaseTrainer:
     Base class for all trainers
     """
     def __init__(self, model, loss, metrics, optimizer, epochs,
-                 save_dir, save_freq, resume, verbosity, training_name,
+                 save_dir, save_freq, resume, verbosity, training_name, device
                  train_logger=None, monitor='loss', monitor_mode='min'):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.model = model
@@ -22,7 +22,7 @@ class BaseTrainer:
         self.verbosity = verbosity
         self.training_name = training_name
         self.train_logger = train_logger
-        # self.device = device
+        self.device = device
         self.monitor = monitor
         self.monitor_mode = monitor_mode
         assert monitor_mode == 'min' or monitor_mode == 'max'
@@ -107,5 +107,9 @@ class BaseTrainer:
         self.monitor_best = checkpoint['monitor_best']
         self.model.load_state_dict(checkpoint['state_dict'])
         self.optimizer.load_state_dict(checkpoint['optimizer'])
+        for state in self.optimizer.state.values():
+            for k, v in state.items():
+                if isinstance(v, torch.Tensor):
+                    state[k] = v.to(self.device)
         self.train_logger = checkpoint['logger']
         self.logger.info("Checkpoint '{}' (epoch {}) loaded".format(resume_path, self.start_epoch))

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -5,43 +5,17 @@ from base import BaseDataLoader
 
 
 class MnistDataLoader(BaseDataLoader):
-    def __init__(self, data_dir, batch_size, shuffle=False):
+    def __init__(self, data_dir, batch_size, validation_split=0.0, validation_fold=0, shuffle=False, num_workers=4):
         """
         :param data_dir: Data directory
         """
-        super(MnistDataLoader, self).__init__(batch_size, shuffle)
         self.data_dir = data_dir
-        self.data_loader = torch.utils.data.DataLoader(
-            datasets.MNIST('../data', train=True, download=True,
-                           transform=transforms.Compose([
-                               transforms.ToTensor(),
-                               transforms.Normalize((0.1307,), (0.3081,))
-                           ])), batch_size=256, shuffle=False)
-        self.x = []
-        self.y = []
-        for data, target in self.data_loader:
-            self.x += [i for i in data.numpy()]
-            self.y += [i for i in target.numpy()]
-        self.x = np.array(self.x)
-        self.y = np.array(self.y)
+        self.batch_size = batch_size
+        trsfm = transforms.Compose([
+            transforms.ToTensor(), 
+            transforms.Normalize((0.1307,), (0.3081,))
+        ])
+        self.dataset = datasets.MNIST('../data', train=True, download=True, transform=trsfm)
+        
+        super(MnistDataLoader, self).__init__(self.dataset, self.batch_size, shuffle, validation_split, validation_fold, num_workers)
 
-    def __next__(self):
-        batch = super(MnistDataLoader, self).__next__()
-        batch = [np.array(sample) for sample in batch]
-        return batch
-
-    def _pack_data(self):
-        packed = list(zip(self.x, self.y))
-        return packed
-
-    def _unpack_data(self, packed):
-        unpacked = list(zip(*packed))
-        unpacked = [list(item) for item in unpacked]
-        return unpacked
-
-    def _update_data(self, unpacked):
-        self.x = unpacked[0]
-        self.y = unpacked[1]
-
-    def _n_samples(self):
-        return len(self.x)

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -5,17 +5,18 @@ from base import BaseDataLoader
 
 
 class MnistDataLoader(BaseDataLoader):
-    def __init__(self, data_dir, batch_size, validation_split=0.0, validation_fold=0, shuffle=False, num_workers=4):
+    def __init__(self, data_dir, batch_size, valid_batch_size=1000, validation_split=0.0, validation_fold=0, shuffle=False, num_workers=4):
         """
         :param data_dir: Data directory
         """
         self.data_dir = data_dir
         self.batch_size = batch_size
+        self.valid_batch_size = valid_batch_size
         trsfm = transforms.Compose([
             transforms.ToTensor(), 
             transforms.Normalize((0.1307,), (0.3081,))
         ])
         self.dataset = datasets.MNIST('../data', train=True, download=True, transform=trsfm)
         
-        super(MnistDataLoader, self).__init__(self.dataset, self.batch_size, shuffle, validation_split, validation_fold, num_workers)
+        super(MnistDataLoader, self).__init__(self.dataset, self.batch_size, self.valid_batch_size, shuffle, validation_split, validation_fold, num_workers)
 

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,1 @@
+from datasets.datasets import *

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -2,3 +2,20 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 
+
+class My_Dataset(Dataset):
+    def __init__(self, data_dir, transform=None, target_transform=None):
+        self.transform = transform
+        self.target_transform = target_transform
+        raise NotImplementedError
+
+    def __getitem__(self, idx):
+        data, target = None, None
+        if self.transform is not None:
+            data = self.transform(data)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        raise NotImplementedError
+        return data, target

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -1,0 +1,4 @@
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+

--- a/model/metric.py
+++ b/model/metric.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 
 def accuracy(y_input, y_target):

--- a/model/metric.py
+++ b/model/metric.py
@@ -1,19 +1,35 @@
 import numpy as np
 
 
-def my_metric(y_input, y_target):
-    assert len(y_input) == len(y_target)
-    correct = 0
-    for y0, y1 in zip(y_input, y_target):
-        if np.array_equal(y0, y1):
-            correct += 1
-    return correct / len(y_input)
+def accuracy(y_input, y_target):
+    pred = torch.argmax(y_input, dim=1)
+    assert pred.shape[0] == y_target.shape[0]
+    correct = torch.sum(pred == y_target, dtype=torch.float32)
+    return (correct / y_target.shape[0]).item()
+
+def top3(y_input, y_target):
+    _, pred = torch.topk(y_input, 3, dim=1)
+    assert pred.shape[0] == y_target.shape[0]
+    score = torch.zeros(1).cuda()
+    for i in range(3):
+        score += torch.sum(pred[:, i] == y_target, dtype=torch.float32) / (i + 1)
+    return (score / y_target.shape[0]).item()
 
 
-def my_metric2(y_input, y_target):
-    assert len(y_input) == len(y_target)
-    correct = 0
-    for y0, y1 in zip(y_input, y_target):
-        if np.array_equal(y0, y1):
-            correct += 1
-    return correct / len(y_input) * 2
+# def my_metric(y_input, y_target):
+#     assert len(y_input) == len(y_target)
+#     correct = 0
+#     for y0, y1 in zip(y_input, y_target):
+#         if np.array_equal(y0, y1):
+#             correct += 1
+#     return correct / len(y_input)
+
+
+# def my_metric2(y_input, y_target):
+#     assert len(y_input) == len(y_target)
+#     correct = 0
+#     for y0, y1 in zip(y_input, y_target):
+#         if np.array_equal(y0, y1):
+#             correct += 1
+#     return correct / len(y_input) * 2
+

--- a/train.py
+++ b/train.py
@@ -76,7 +76,7 @@ def main(args):
                       training_name=training_name,
                       with_cuda=not args.no_cuda,
                       lr_scheduler=lr_scheduler,
-                      monitor='val_my_metric',
+                      monitor='accuracy',
                       monitor_mode='max')
 
     # Start training!

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import tensorboardX
+import torch
 import torch.optim as optim
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from model.model import MnistModel
@@ -42,6 +43,7 @@ parser.add_argument('--no-cuda', action="store_true",
 
 
 def main(args):
+    device = torch.device('cuda:0' if torch.cuda.is_available() and not args.no_cuda else 'cpu')
     # Model
     model = MnistModel()
     model.summary()
@@ -74,7 +76,7 @@ def main(args):
                       resume=args.resume,
                       verbosity=args.verbosity,
                       training_name=training_name,
-                      with_cuda=not args.no_cuda,
+                      device=device,
                       lr_scheduler=lr_scheduler,
                       monitor='accuracy',
                       monitor_mode='max')

--- a/train.py
+++ b/train.py
@@ -22,8 +22,8 @@ parser.add_argument('-e', '--epochs', default=32, type=int,
                     help='number of total epochs (default: 32)')
 parser.add_argument('--lr', default=0.001, type=float,
                     help='learning rate (default: 0.001)')
-parser.add_argument('--wd', default=0.001, type=float,
-                    help='weight decay (default: 0.001)')
+parser.add_argument('--wd', default=0.0, type=float,
+                    help='weight decay (default: 0.0)')
 parser.add_argument('--resume', default='', type=str,
                     help='path to latest checkpoint (default: none)')
 parser.add_argument('--verbosity', default=2, type=int,
@@ -34,6 +34,8 @@ parser.add_argument('--save-freq', default=1, type=int,
                     help='training checkpoint frequency (default: 1)')
 parser.add_argument('--data-dir', default='datasets', type=str,
                     help='directory of training/testing data (default: datasets)')
+parser.add_argument('--valid-batch-size', default=1000, type=int,
+                    help='mini-batch size (default: 1000)')
 parser.add_argument('--validation-split', default=0.1, type=float,
                     help='ratio of split validation data, [0.0, 1.0) (default: 0.1)')
 parser.add_argument('--validation-fold', default=0, type=int,
@@ -58,7 +60,7 @@ def main(args):
     lr_scheduler = ReduceLROnPlateau(optimizer, mode='min', factor=0.1, patience=10)
 
     # Data loader and validation split
-    data_loader = MnistDataLoader(args.data_dir, args.batch_size, args.validation_split, args.validation_fold, shuffle=True, num_workers=4)
+    data_loader = MnistDataLoader(args.data_dir, args.batch_size, args.valid_batch_size, args.validation_split, args.validation_fold, shuffle=True, num_workers=4)
     valid_data_loader = data_loader.get_valid_loader()
 
     # An identifier for this training session

--- a/train.py
+++ b/train.py
@@ -15,6 +15,8 @@ parser.add_argument('-b', '--batch-size', default=32, type=int,
                     help='mini-batch size (default: 32)')
 parser.add_argument('-e', '--epochs', default=32, type=int,
                     help='number of total epochs (default: 32)')
+parser.add_argument('--lr', default=0.001, type=float,
+                    help='learning rate (default: 0.001)')
 parser.add_argument('--resume', default='', type=str,
                     help='path to latest checkpoint (default: none)')
 parser.add_argument('--verbosity', default=2, type=int,
@@ -42,7 +44,7 @@ def main(args):
     # Specifying loss function, metric(s), and optimizer
     loss = my_loss
     metrics = [my_metric, my_metric2]
-    optimizer = optim.Adam(model.parameters())
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
 
     # Data loader and validation split
     data_loader = MnistDataLoader(args.data_dir, args.batch_size, shuffle=True)

--- a/train.py
+++ b/train.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import tensorboardX
 import torch.optim as optim
 from model.model import MnistModel
 from model.loss import my_loss
@@ -8,7 +9,9 @@ from data_loader import MnistDataLoader
 from trainer import Trainer
 from logger import Logger
 
+
 logging.basicConfig(level=logging.INFO, format='')
+
 
 parser = argparse.ArgumentParser(description='PyTorch Template')
 parser.add_argument('-b', '--batch-size', default=32, type=int,
@@ -17,6 +20,8 @@ parser.add_argument('-e', '--epochs', default=32, type=int,
                     help='number of total epochs (default: 32)')
 parser.add_argument('--lr', default=0.001, type=float,
                     help='learning rate (default: 0.001)')
+parser.add_argument('--wd', default=0.001, type=float,
+                    help='weight decay (default: 0.001)')
 parser.add_argument('--resume', default='', type=str,
                     help='path to latest checkpoint (default: none)')
 parser.add_argument('--verbosity', default=2, type=int,
@@ -44,11 +49,11 @@ def main(args):
     # Specifying loss function, metric(s), and optimizer
     loss = my_loss
     metrics = [my_metric, my_metric2]
-    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+    optimizer = optim.Adam(model.parameters(), lr=args.lr, weight_decay=args.wd, amsgrad=True)
 
     # Data loader and validation split
-    data_loader = MnistDataLoader(args.data_dir, args.batch_size, shuffle=True)
-    valid_data_loader = data_loader.split_validation(args.validation_split)
+    data_loader = MnistDataLoader(args.data_dir, args.batch_size, args.validation_split, shuffle=True, num_workers=4)
+    valid_data_loader = data_loader.get_valid_loader()
 
     # An identifier for this training session
     training_name = type(model).__name__

--- a/train.py
+++ b/train.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import tensorboardX
 import torch
 import torch.optim as optim
 from torch.optim.lr_scheduler import ReduceLROnPlateau
@@ -10,9 +9,10 @@ from model.metric import accuracy
 from data_loader import MnistDataLoader
 from trainer import Trainer
 from logger import Logger
-
+from tensorboardX import SummaryWriter
 
 logging.basicConfig(level=logging.INFO, format='')
+writer = SummaryWriter('/data1/home/hmroh/projects2018/SunQ/runs')
 
 
 parser = argparse.ArgumentParser(description='PyTorch Template')
@@ -73,6 +73,7 @@ def main(args):
                       optimizer=optimizer,
                       epochs=args.epochs,
                       train_logger=train_logger,
+                      writer=writer,
                       save_dir=args.save_dir,
                       save_freq=args.save_freq,
                       resume=args.resume,

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -14,10 +14,10 @@ class Trainer(BaseTrainer):
     """
     def __init__(self, model, loss, metrics, data_loader, optimizer, epochs,
                  save_dir, save_freq, resume, with_cuda, verbosity, training_name='',
-                 valid_data_loader=None, train_logger=None, monitor='loss', monitor_mode='min'):
+                 valid_data_loader=None, train_logger=None, lr_scheduler=None, monitor='loss', monitor_mode='min'):
         super(Trainer, self).__init__(model, loss, metrics, optimizer, epochs,
                                       save_dir, save_freq, resume, verbosity, training_name,
-                                      with_cuda, train_logger, lr_scheduler, monitor, monitor_mode)
+                                      with_cuda, train_logger, monitor, monitor_mode)
         self.batch_size = data_loader.batch_size
         self.data_loader = data_loader
         self.valid_data_loader = valid_data_loader

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -17,11 +17,12 @@ class Trainer(BaseTrainer):
                  valid_data_loader=None, train_logger=None, monitor='loss', monitor_mode='min'):
         super(Trainer, self).__init__(model, loss, metrics, optimizer, epochs,
                                       save_dir, save_freq, resume, verbosity, training_name,
-                                      with_cuda, train_logger, monitor, monitor_mode)
+                                      with_cuda, train_logger, lr_scheduler, monitor, monitor_mode)
         self.batch_size = data_loader.batch_size
         self.data_loader = data_loader
         self.valid_data_loader = valid_data_loader
         self.valid = True if self.valid_data_loader is not None else False
+        self.scheduler = lr_scheduler
 
     def _to_variable(self, data, target):
         # data, target = Variable(data), Variable(target)
@@ -60,10 +61,8 @@ class Trainer(BaseTrainer):
             self.optimizer.step()
 
             for i, metric in enumerate(self.metrics):
-                y_output = output.data.cpu().numpy()
-                y_output = np.argmax(y_output, axis=1)
-                y_target = target.data.cpu().numpy()
-                total_metrics[i] += metric(y_output, y_target)
+                score = metric(output, target)
+                total_metrics[i] += score
 
             total_loss += loss.item()
             log_step = int(np.sqrt(self.batch_size))
@@ -99,11 +98,10 @@ class Trainer(BaseTrainer):
             total_val_loss += loss.item()
 
             for i, metric in enumerate(self.metrics):
-                y_output = output.data.cpu().numpy()
-                y_output = np.argmax(y_output, axis=1)
-                y_target = target.data.cpu().numpy()
-                total_val_metrics[i] += metric(y_output, y_target)
+                score = metric(output, target)
+                total_val_metrics[i] += score
 
         avg_val_loss = total_val_loss / len(self.valid_data_loader)
+        self.scheduler.step(avg_val_loss)
         avg_val_metrics = (total_val_metrics / len(self.valid_data_loader)).tolist()
         return {'val_loss': avg_val_loss, 'val_metrics': avg_val_metrics}

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -17,8 +17,7 @@ class Trainer(BaseTrainer):
                  valid_data_loader=None, train_logger=None, lr_scheduler=None, monitor='loss', monitor_mode='min'):
         super(Trainer, self).__init__(model, loss, metrics, optimizer, epochs,
                                       save_dir, save_freq, resume, verbosity, training_name,
-                                      train_logger, monitor, monitor_mode)
-        self.device = device
+                                      device, train_logger, monitor, monitor_mode)
         self.batch_size = data_loader.batch_size
         self.data_loader = data_loader
         self.valid_data_loader = valid_data_loader

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -24,8 +24,8 @@ class Trainer(BaseTrainer):
         self.valid = True if self.valid_data_loader is not None else False
 
     def _to_variable(self, data, target):
+        # data, target = Variable(data), Variable(target)
         data, target = torch.FloatTensor(data), torch.LongTensor(target)
-        data, target = Variable(data), Variable(target)
         if self.with_cuda:
             data, target = data.cuda(), target.cuda()
         return data, target
@@ -65,12 +65,12 @@ class Trainer(BaseTrainer):
                 y_target = target.data.cpu().numpy()
                 total_metrics[i] += metric(y_output, y_target)
 
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             log_step = int(np.sqrt(self.batch_size))
             if self.verbosity >= 2 and batch_idx % log_step == 0:
                 self.logger.info('Train Epoch: {} [{}/{} ({:.0f}%)] Loss: {:.6f}'.format(
                     epoch, batch_idx * len(data), len(self.data_loader) * len(data),
-                    100.0 * batch_idx / len(self.data_loader), loss.data[0]))
+                    100.0 * batch_idx / len(self.data_loader), loss.item()))
 
         avg_loss = total_loss / len(self.data_loader)
         avg_metrics = (total_metrics / len(self.data_loader)).tolist()
@@ -96,7 +96,7 @@ class Trainer(BaseTrainer):
 
             output = self.model(data)
             loss = self.loss(output, target)
-            total_val_loss += loss.data[0]
+            total_val_loss += loss.item()
 
             for i, metric in enumerate(self.metrics):
                 y_output = output.data.cpu().numpy()


### PR DESCRIPTION
I have discovered that data loader of this template packs all data into a python list, to split validation set. Although doing this is not a problem when dealing with small datasets like mnist, it is not suitable for normal datasets which are too big to be contained into memory. I replaced this with torch.utils.data.sampler.SubsetRandomSampler which specifies indices to be selected in a data loader.

By the way, I have been using this template for about 3 months changing things, so this request will contain  some unimportant small changes. Sorry for not organizing things before pulling request.