### PR TITLE
Added fn to select data loader (instead of Mnist hardcoded in train.py)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Config files are in `.json` format:
     "name": "Mnist_LeNet",        // training session name
     "cuda": true,                 // use cuda
     "data_loader": {
+		"type": "MnistDataLoader" // selecting data loader
         "data_dir": "datasets/",  // dataset path
         "batch_size": 32,         // batch size
         "shuffle": true           // shuffle data each time calling __iter__()

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -44,9 +44,12 @@ class BaseTrainer:
         self.monitor_best = math.inf if self.monitor_mode == 'min' else -math.inf
         self.start_epoch = 1
         self.checkpoint_dir = os.path.join(config['trainer']['save_dir'], self.name)
+
+        # Save configuration into checkpoint directory:
         ensure_dir(self.checkpoint_dir)
-        json.dump(config, open(os.path.join(self.checkpoint_dir, 'config.json'), 'w'),
-                  indent=4, sort_keys=False)
+        with open(self.checkpoint_dir, 'config.json', 'w') as handle:
+            json.dump(config, handle, indent=4, sort_keys=False)
+
         if resume:
             self._resume_checkpoint(resume)
 

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "cuda": true,
     "gpu": 0,
     "data_loader": {
+        "type": "MnistDataLoader",
         "data_dir": "datasets/",
         "batch_size": 32,
         "shuffle": true

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -4,6 +4,16 @@ from torchvision import datasets, transforms
 from base import BaseDataLoader
 
 
+def get_data_loader(config):
+    """Returns data loader as specified in configuration."""
+    loader_type = config['data_loader']['type']
+
+    if loader_type == 'MnistDataLoader':
+        return MnistDataLoader(config)
+    else:
+        raise NotImplementedError(f"Loader {loader_type} not implemented.")
+
+
 class MnistDataLoader(BaseDataLoader):
     """
     MNIST data loading demo using BaseDataLoader

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ import torch
 from model.model import *
 from model.loss import *
 from model.metric import *
-from data_loader import MnistDataLoader
+from data_loader import get_data_loader
 from trainer import Trainer
 from logger import Logger
 
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.INFO, format='')
 def main(config, resume):
     train_logger = Logger()
 
-    data_loader = MnistDataLoader(config)
+    data_loader = get_data_loader(config)
     valid_data_loader = data_loader.split_validation()
 
     model = eval(config['arch'])(config['model'])

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -18,7 +18,7 @@ class Trainer(BaseTrainer):
         self.batch_size = data_loader.batch_size
         self.data_loader = data_loader
         self.valid_data_loader = valid_data_loader
-        self.valid = True if self.valid_data_loader is not None else False
+        self.do_validation = self.valid_data_loader is not None
         self.log_step = int(np.sqrt(self.batch_size))
 
     def _to_tensor(self, data, target):
@@ -81,7 +81,7 @@ class Trainer(BaseTrainer):
             'metrics': (total_metrics / len(self.data_loader)).tolist()
         }
 
-        if self.valid:
+        if self.do_validation:
             val_log = self._valid_epoch()
             log = {**log, **val_log}
 


### PR DESCRIPTION
Hi,

Created initial proposal for selecting data loader in configuration file.

**Overview:**
- User can select data loader in configuration file
- New data loaders are (for now*) written in 'data_loader.data_loaders.py'
- Currently, the function 'get_data_loader' needs to be manually when adding new loaders (in addition to writing the loader class)

I propose this as a first step that we can build further on**.

Comment:
*: I guess we over time can implement functionality to load loaders from new files inside the 'data_loader' module (if someone prefers to create 'data_loader/my_new_loader.py')
**: I plan to implement another data loader that potentially can work as another example in the template. Will post when this is done.