### PR TITLE
Created 'get_xyz' fns, replaced 'import *' in 'train.py'.

### DIFF
--- a/model/loss.py
+++ b/model/loss.py
@@ -1,5 +1,12 @@
 import torch.nn.functional as F
 
+def get_loss_function(loss_fn_name):
+    try:
+        loss_fn = eval(loss_fn_name)
+    except NameError as e:
+        raise NameError(f"Loss function '{loss_fn_name}' not found.")
+
+    return loss_fn
 
 def my_loss(y_input, y_target):
     return F.nll_loss(y_input, y_target)

--- a/model/metric.py
+++ b/model/metric.py
@@ -1,6 +1,15 @@
 import numpy as np
 
 
+def get_metric_functions(metric_names):
+    try:
+        metric_fns = [eval(metric) for metric in metric_names]
+    except NameError as e:
+        raise NameError(f"One of metric functions ({metric_names}) not found.")
+
+    return metric_fns
+
+
 def my_metric(y_input, y_target):
     assert len(y_input) == len(y_target)
     correct = 0

--- a/model/model.py
+++ b/model/model.py
@@ -2,6 +2,16 @@ from base import BaseModel
 import torch.nn as nn
 import torch.nn.functional as F
 
+def get_model_instance(model_arch, model_params):
+    try:
+        model = eval(model_arch)
+    except NameError:
+        raise NameError(f"Model '{model_arch}' not found.")
+
+    model_instance = model(model_params)
+
+    return model_instance
+
 
 class MnistModel(BaseModel):
     def __init__(self, config):

--- a/train.py
+++ b/train.py
@@ -3,10 +3,10 @@ import json
 import logging
 import argparse
 import torch
-from model.model import *
-from model.loss import *
-from model.metric import *
 from data_loader import MnistDataLoader
+from model.model import get_model_instance
+from model.loss import get_loss_function
+from model.metric import get_metric_functions
 from trainer import Trainer
 from logger import Logger
 
@@ -19,11 +19,12 @@ def main(config, resume):
     data_loader = MnistDataLoader(config)
     valid_data_loader = data_loader.split_validation()
 
-    model = eval(config['arch'])(config['model'])
+    model = get_model_instance(model_arch=config['arch'],
+                               model_params=config['model'])
     model.summary()
 
-    loss = eval(config['loss'])
-    metrics = [eval(metric) for metric in config['metrics']]
+    loss = get_loss_function(config['loss'])
+    metrics = get_metric_functions(config['metrics'])
 
     trainer = Trainer(model, loss, metrics,
                       resume=resume,


### PR DESCRIPTION
Hi @victoresque ,

I added three get functions:
- 'model.model.get_model_instance'
- model.loss.get_loss_function'
'model.metric.get_metric_functions'

These **replace the 'import \*'** instances in 'train.py' and makes the code easier to read. 

Further, the update aligns better with the 'best practice' of [Flake8 rule F405](https://lintlyci.github.io/Flake8Rules/rules/F405.html).

Let me know if you believe I should update/change something.