### PR TITLE
Rewrite visualization.py, add no_grad flag on metric 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If TensorboardX is used:
   │
   ├── logger/ - for training process logging
   │   └── logger.py
+  │   └── visualization.py
   │
   ├── model/ - models, losses, and metrics
   │   ├── modules/ - submodules of your model

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Config files are in `.json` format:
         "monitor_mode": "min"     // "min" if monitor value the lower the better, otherwise "max" 
     },
     "visualization":{
-        "tensorboardX": false,
-        "log_dir": "saved/runs"
+        "tensorboardX": false,    // enable tensorboardX visualization support
+        "log_dir": "saved/runs"   // directory to save log files for visualization
     },
     "arch": "MnistModel",         // model architecture
     "model": {}                   // model configs

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -16,58 +16,22 @@ class WriterTensorboardX():
         self.step = 0
         self.mode = ''
 
+        self.tensorboard_writer_ftns = ['add_scalar', 'add_scalars', 'add_image', 'add_audio', 'add_text', 'add_histogram', 'add_pr_curve', 'add_embedding']
+
     def set_step(self, step, mode='train'):
         self.mode = mode
         self.step = step
 
-    def add_image(self, tag, image):
-        if self.writer is None:
-            pass
+    def __getattr__(self, name):
+        if name in self.tensorboard_writer_ftns:
+            # get add_something method of tensorboard summary writer
+            attr = getattr(self.writer, name, None)
+            # wrap default methods to be harmless when writer is not set
+            def wrapper(tag, data, *args, **kwargs):
+                if attr is None:
+                    pass
+                else:
+                    attr(f'{self.mode}/{tag}', data, self.step, *args, **kwargs)
+            return wrapper
         else:
-            self.writer.add_image(f'{self.mode}/{tag}', image, self.step)
-
-    def add_scalar(self, tag, data):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_scalar(f'{self.mode}/{tag}', data, self.step)
-
-    def add_scalars(self, tag, data):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_scalars(f'{self.mode}/{tag}', data, self.step)   
-
-    def add_audio(self, tag, audio, sample_rate=44100):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_audio(f'{self.mode}/{tag}', audio, self.step, sample_rate=sample_rate)
-
-    def add_text(self, tag, data):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_text(f'{self.mode}/{tag}', data, self.step)   
-
-    def add_histogram(self, tag, data):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_histogram(f'{self.mode}/{tag}', data, self.step)
-
-    def add_pr_curve(self, tag, pred, data=None):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_pr_curve(f'{self.mode}/{tag}', pred, data, self.step)
-
-    def add_embedding(self, tag, features, metadata=None, label_img=None):
-        if self.writer is None:
-            pass
-        else:
-            self.writer.add_embedding(features, metadata=metadata, label_img=label_img)
-
-
-if __name__ == '__main__':
-    pass
+            return super(WriterTensorboardX, self).__getattr__(name)

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -38,4 +38,4 @@ class WriterTensorboardX():
             return wrapper
         else:
             # default action for returning methods defined in this class, set_step() for instance.
-            return super(WriterTensorboardX, self).__getattr__(name)
+            return object.__getattr__(name)

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import warnings
 from datetime import datetime
 
 
@@ -12,8 +13,8 @@ class WriterTensorboardX():
             try:
                 self.writer = importlib.import_module('tensorboardX').SummaryWriter(log_path)
             except ModuleNotFoundError:
-                print('Package tensorboardX is not installed.')
-                # TODO: make a proper warning or raise exception here
+                message = """TensorboardX visualization is configured to use, but currently not installed on this machine. Please install the package by 'pip install tensorboardx' command or turn off the option in the 'config.json' file."""
+                warnings.warn(message, UserWarning)
         self.step = 0
         self.mode = ''
 

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -31,7 +31,7 @@ class WriterTensorboardX():
                 if attr is None:
                     pass
                 else:
-                    attr(f'{self.mode}/{tag}', data, self.step, *args, **kwargs)
+                    attr('{}/{}'.format(self.mode, tag), data, self.step, *args, **kwargs)
             return wrapper
         else:
             return super(WriterTensorboardX, self).__getattr__(name)

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -38,4 +38,8 @@ class WriterTensorboardX():
             return wrapper
         else:
             # default action for returning methods defined in this class, set_step() for instance.
-            return object.__getattr__(name)
+            try:
+                attr = object.__getattr__(name)
+            except AttributeError:
+                raise AttributeError("type object 'WriterTensorboardX' has no attribute '{}'".format(name))
+            return attr

--- a/model/metric.py
+++ b/model/metric.py
@@ -2,16 +2,18 @@ import torch
 
 
 def my_metric(output, target):
-    pred = torch.argmax(output, dim=1)
-    assert pred.shape[0] == len(target)
-    correct = 0
-    correct += torch.sum(pred == target).item()
+    with torch.no_grad():
+        pred = torch.argmax(output, dim=1)
+        assert pred.shape[0] == len(target)
+        correct = 0
+        correct += torch.sum(pred == target).item()
     return correct / len(target)
 
 def my_metric2(output, target, k=3):
-    pred = torch.topk(output, k, dim=1)[1]
-    assert pred.shape[0] == len(target)
-    correct = 0
-    for i in range(k):
-        correct += torch.sum(pred[:, i] == target).item()
+    with torch.no_grad():
+        pred = torch.topk(output, k, dim=1)[1]
+        assert pred.shape[0] == len(target)
+        correct = 0
+        for i in range(k):
+            correct += torch.sum(pred[:, i] == target).item()
     return correct / len(target)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -58,7 +58,7 @@ class Trainer(BaseTrainer):
             loss.backward()
             self.optimizer.step()
 
-            self.writer.set_step(epoch * len(self.data_loader) + batch_idx)
+            self.writer.set_step((epoch - 1) * len(self.data_loader) + batch_idx)
             self.writer.add_scalar('loss', loss.item())
             total_loss += loss.item()
             total_metrics += self._eval_metrics(output, target)
@@ -102,7 +102,7 @@ class Trainer(BaseTrainer):
                 output = self.model(data)
                 loss = self.loss(output, target)
 
-                self.writer.set_step(epoch * len(self.data_loader) + batch_idx, 'valid')
+                self.writer.set_step((epoch - 1) * len(self.data_loader) + batch_idx, 'valid')
                 self.writer.add_scalar('loss', loss.item())
                 total_val_loss += loss.item()
                 total_val_metrics += self._eval_metrics(output, target)


### PR DESCRIPTION
Hi, @victoresque 
This is some additional changes from my previous one. 
Major changes are adding `torch.no_grad()` flag for computation of example metrics, and replacing manual wrapping of tensorboard functions with inheritance of `__getattr__` method.
I also changed string formatting literals used in `visualization.py` to old style which is compatible with python 3.5 
Thanks.