### PR TITLE
Update loss file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Config files are in `.json` format:
         "weight_decay": 0         // (optional) weight decay
     },
     "loss": "NLLLoss",            // loss
+    "loss_args": {
+        "reduction": "elementwise_mean"
+    },                            // elements in "loss_args" will be passed as kwargs to loss object
     "metrics": [                  // metrics
       "my_metric",
       "my_metric2"
@@ -211,7 +214,9 @@ You can resume from a previously saved checkpoint by:
   Please refer to `model/model.py` for a LeNet example.
 
 ### Loss
-Valid values for 'loss' in the configuration file are all class names inside 'torch.nn.modules.loss' (see [PyTorch documentation](https://pytorch.org/docs/stable/nn.html#loss-functions)).
+Valid values for 'loss' in the configuration file are all class names inside 'torch.nn.modules.loss' (see [PyTorch documentation](https://pytorch.org/docs/stable/nn.html#loss-functions)). 
+The configuration key 'loss_args' is a dictionary that is passed dictionary that is passed as keyword arguments during loss object
+initialization.
 
 Custom loss functions can be implemented in 'model/loss.py', however using them currently requires explicitly importing the custom loss function manually in 'train.py'.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Config files are in `.json` format:
         "lr": 0.001,              // (optional) learning rate
         "weight_decay": 0         // (optional) weight decay
     },
-    "loss": "my_loss",            // loss
+    "loss": "NLLLoss",            // loss
     "metrics": [                  // metrics
       "my_metric",
       "my_metric2"
@@ -198,11 +198,15 @@ You can resume from a previously saved checkpoint by:
 
   Please refer to `model/model.py` for a LeNet example.
 
-### Loss and metrics
-If you need to change the loss function or metrics, first `import` those function in `train.py`, then modify `"loss"` and `"metrics"` in `.json` config files
+### Loss
+Valid values for 'loss' in the configuration file are all class names inside 'torch.nn.modules.loss' (see [PyTorch documentation](https://pytorch.org/docs/stable/nn.html#loss-functions)).
 
-#### Multiple metrics
-You can add multiple metrics in your config files:
+Custom loss functions can be implemented in 'model/loss.py', however using them currently requires explicitly importing the custom loss function manually in 'train.py'.
+
+#### Metrics
+Metric functions are located in 'model/metric.py'.
+
+You can monitor multiple metrics by providing a list in the configuration file, e.g.:
   ```json
   "metrics": ["my_metric", "my_metric2"],
   ```

--- a/config.json
+++ b/config.json
@@ -25,6 +25,9 @@
         "weight_decay": 0
     },
     "loss": "NLLLoss",
+    "loss_args": {
+        "reduction": "elementwise_mean"
+    },
     "metrics": ["my_metric", "my_metric2"],
     "trainer": {
         "epochs": 1000,

--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
         "lr": 0.001,
         "weight_decay": 0
     },
-    "loss": "my_loss",
+    "loss": "NLLLoss",
     "metrics": ["my_metric", "my_metric2"],
     "trainer": {
         "epochs": 1000,

--- a/model/loss.py
+++ b/model/loss.py
@@ -4,7 +4,7 @@ from torch.nn.modules import loss
 def get_loss_function(loss_name, *args, **kwargs):
     """Creates and returns instance of loss function class.
 
-    All *args and *kwargs are passed to initialization of loss class.
+    All *args and **kwargs are passed to initialization of loss class.
 
     :param loss_name: Valid values of 'loss_name' are all class names inside 'torch.nn.modules.loss'.
         See 'https://pytorch.org/docs/stable/nn.html#loss-functions'.
@@ -23,13 +23,13 @@ def get_loss_function(loss_name, *args, **kwargs):
 class CustomLossClass(loss._Loss):
     """Your custom loss function implementation"""
     def __init__(self):
-        super(_Loss, self).__init__()
+        super(CustomLossClass, self).__init__()
 
         # Your initialization goes here
 
         raise NotImplementedError
 
-    def forward(self, input, target):
+    def forward(self, output, target):
         # Forward calculation of custom loss function goes here.
 
         raise NotImplementedError

--- a/model/loss.py
+++ b/model/loss.py
@@ -1,12 +1,36 @@
-import torch.nn.functional as F
+from torch.nn.modules import loss
 
-def get_loss_function(loss_fn_name):
+
+def get_loss_function(loss_name, *args, **kwargs):
+    """Creates and returns instance of loss function class.
+
+    All *args and *kwargs are passed to initialization of loss class.
+
+    :param loss_name: Valid values of 'loss_name' are all class names inside 'torch.nn.modules.loss'.
+        See 'https://pytorch.org/docs/stable/nn.html#loss-functions'.
+    :return: Instance of loss function class.
+    """
+    # TODO: Implement functionality that scans for classes inside this file making them available.
     try:
-        loss_fn = eval(loss_fn_name)
-    except NameError as e:
-        raise NameError(f"Loss function '{loss_fn_name}' not found.")
+        loss_fn = getattr(loss, loss_name)
 
-    return loss_fn
+    except AttributeError:
+        raise AttributeError("Loss function '{}' not found.".format(loss_name))
 
-def my_loss(y_input, y_target):
-    return F.nll_loss(y_input, y_target)
+    return loss_fn(*args, **kwargs)
+
+
+class CustomLossClass(loss._Loss):
+    """Your custom loss function implementation"""
+    def __init__(self):
+        super(_Loss, self).__init__()
+
+        # Your initialization goes here
+
+        raise NotImplementedError
+
+    def forward(self, input, target):
+        # Forward calculation of custom loss function goes here.
+
+        raise NotImplementedError
+

--- a/train.py
+++ b/train.py
@@ -23,7 +23,7 @@ def main(config, resume):
                                model_params=config['model'])
     model.summary()
 
-    loss = get_loss_function(config['loss'])
+    loss = get_loss_function(config['loss'], **config['loss_args'])
     metrics = get_metric_functions(config['metrics'])
 
     trainer = Trainer(model, loss, metrics,


### PR DESCRIPTION
With reference to issue #21:
I have done the update I described in the issue.

Now the loss functionality can use all PyTorch loss functions (by specifying the name in config.json). A template of a custom loss function class is included.

Remaining:
- Functionality that checks if config['loss'] matches one of the custom classes in 'model/loss.py'
    - When we implement this, we need to decide if custom loss functions ('model/loss.py' ones) or standard PyTorch losses has precedence (in case someone implements a loss function with the same name as PyTorch standard losses, either by accident or on purpose)