### PR TITLE
Add combined command line options for fine-tuning

### DIFF
--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -142,23 +142,18 @@ class BaseTrainer:
         self.start_epoch = checkpoint['epoch'] + 1
         self.monitor_best = checkpoint['monitor_best']
 
-        # load architecture from checkpoint.
-        if self.config['arch'] != checkpoint['arch']:
-            self.logger.warning('Architecture setting given in config file is different from that of checkpoint. ' + \
-                                'This may produce an exception while loading state_dict.')
+        # load architecture params from checkpoint.
+        if checkpoint['config']['arch'] != self.config['arch']:
+            self.logger.warning('Warning: Architecture configuration given in config file is different from that of checkpoint. ' + \
+                                'This may yield an exception while state_dict is being loaded.')
         self.model.load_state_dict(checkpoint['state_dict'])
 
-        # load optimizer from checkpoint.
-        if checkpoint['config']['optimizer']['type'] == self.config['optimizer']['type']:
-            self.optimizer.load_state_dict(checkpoint['optimizer'])
-            if self.with_cuda:
-                for state in self.optimizer.state.values():
-                    for k, v in state.items():
-                        if isinstance(v, torch.Tensor):
-                            state[k] = v.cuda(self.device)
-        else:
-            self.logger.warning('Optimizer type given in config file is different from that of checkpoint. ' + \
+        # load optimizer state from checkpoint only when optimizer type is not changed. 
+        if checkpoint['config']['optimizer']['type'] != self.config['optimizer']['type']:
+            self.logger.warning('Warning: Optimizer type given in config file is different from that of checkpoint. ' + \
                                 'Optimizer parameters not being resumed.')
-
+        else:
+            self.optimizer.load_state_dict(checkpoint['optimizer'])
+    
         self.train_logger = checkpoint['logger']
         self.logger.info("Checkpoint '{}' (epoch {}) loaded".format(resume_path, self.start_epoch))

--- a/train.py
+++ b/train.py
@@ -47,23 +47,24 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='PyTorch Template')
 
     parser.add_argument('-f', '--force', action='store_true',
-                        help='')
-    arg_group = parser.add_mutually_exclusive_group(required=True)
-    arg_group.add_argument('-c', '--config', default=None, type=str,
+                           help='ignore existing checkpoint and start training')
+    parser.add_argument('-c', '--config', default=None, type=str,
                            help='config file path (default: None)')
-    arg_group.add_argument('-r', '--resume', default=None, type=str,
+    parser.add_argument('-r', '--resume', default=None, type=str,
                            help='path to latest checkpoint (default: None)')
 
     args = parser.parse_args()
 
-    if args.resume:
-        config = torch.load(args.resume)['config']
-    else:
+    if args.config:
         config = json.load(open(args.config))
         path = os.path.join(config['trainer']['save_dir'], config['name'])
         if os.path.exists(path):
             if not args.force:
-                message = "Path {} already exists. Add '-f' or '--force' option to start training anyway, or change 'name' given in config file.".format(path)
-                raise AssertionError(message)
+                msg = "Path {} already exists. Add '-f' or '--force' option to start training anyway, or change 'name' given in config file.".format(path)
+                raise AssertionError(msg)
+    elif args.resume:
+        config = torch.load(args.resume)['config']
+    else:
+        raise AssertionError("Specify configuration file. By adding '-c config.json' for example.")
 
     main(config, args.resume)


### PR DESCRIPTION
This PR is about issue #25, adding command line options for fine tuning.
I have rearranged the order of config file being set up in `train.py` and added warning for sensitive options(architecture, optimizer) being changed. 

If the config and resume options are given at the same time, instances like model, optimizer are initialized in the `train.py` according to the config file given, than `base_trainer` handles loading checkpoint for that. 

It seems that changing options related to `monitor` is also problematic when changed, but didn't handled that yet.