### PR TITLE
Multi GPU training(data parallel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Config files are in `.json` format:
     "type": "MnistDataLoader",  // selecting data loader
     "args":{
       "data_dir": "data/",      // dataset path
-      "n_cpu": 2,               // number of processes to use for data loading
       "batch_size": 64,         // batch size
       "shuffle": true,          // shuffle training data before splitting
       "validation_split": 0.1   // validation data ratio
+      "num_workers": 2,         // number of cpu processes to be used for data loading
     }
   },
   "optimizer": {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PyTorch deep learning project made easy.
 		* [Config file format](#config-file-format)
 		* [Using config files](#using-config-files)
 		* [Resuming from checkpoints](#resuming-from-checkpoints)
+    * [Using Multiple GPU](#using-multiple-gpu)
 	* [Customization](#customization)
 		* [Data Loader](#data-loader)
 		* [Trainer](#trainer)
@@ -84,14 +85,14 @@ PyTorch deep learning project made easy.
 
 ## Usage
 The code in this repo is an MNIST example of the template.
+Try `python3 train.py -c config.json` to run code.
 
 ### Config file format
 Config files are in `.json` format:
 ```javascript
 {
   "name": "Mnist_LeNet",        // training session name
-  "cuda": true,                 // use cuda
-  "gpu": 0,
+  "n_gpu": 1,                   // number of GPUs to use for training.
   
   "arch": {
     "type": "MnistModel",       // name of model architecture to train
@@ -103,6 +104,7 @@ Config files are in `.json` format:
     "type": "MnistDataLoader",  // selecting data loader
     "args":{
       "data_dir": "data/",      // dataset path
+      "n_cpu": 2,               // number of processes to use for data loading
       "batch_size": 64,         // batch size
       "shuffle": true,          // shuffle training data before splitting
       "validation_split": 0.1   // validation data ratio
@@ -111,7 +113,7 @@ Config files are in `.json` format:
   "optimizer": {
     "type": "Adam",
     "args":{
-      "lr": 0.001,              // (optional) learning rate
+      "lr": 0.001,              // learning rate
       "weight_decay": 0,        // (optional) weight decay
       "amsgrad": true
     }
@@ -121,9 +123,9 @@ Config files are in `.json` format:
     "my_metric", "my_metric2"   // list of metrics to evaluate
   ],                         
   "lr_scheduler": {
-    "type":"StepLR",
+    "type":"StepLR",            // learning rate scheduler
     "args":{
-      "step_size":50,
+      "step_size":50,          
       "gamma":0.1
     }
   },
@@ -156,6 +158,18 @@ You can resume from a previously saved checkpoint by:
 
   ```
   python train.py --resume path/to/checkpoint
+  ```
+
+### Using Multiple GPU
+You can enable multi-GPU training by setting `n_gpu` argument of the config file to larger number.
+If configured to use smaller number of gpu than available, first n devices will be used by default.
+Specify indices of available GPUs by cuda environmental variable.
+  ```
+  python train.py --device 2,3 -c config.json
+  ```
+  This is equivalent to
+  ```
+  CUDA_VISIBLE_DEVICES=2,3 python train.py -c config.py
   ```
 
 ## Customization
@@ -301,12 +315,12 @@ Code should pass the [Flake8](http://flake8.pycqa.org/en/latest/) check before c
 
 ## TODOs
 - [ ] Iteration-based training (instead of epoch-based)
-- [ ] Multi-GPU support
 - [ ] Multiple optimizers
 - [ ] Configurable logging layout, checkpoint naming
-- [ ] Adding command line option for fine-tuning
 - [ ] `visdom` logger support
 - [x] `tensorboardX` logger support
+- [x] Adding command line option for fine-tuning
+- [x] Multi-GPU support
 - [x] Update the example to PyTorch 0.4
 - [x] Learning rate scheduler
 - [x] Deprecate `BaseDataLoader`, use `torch.utils.data` instesad

--- a/base/base_data_loader.py
+++ b/base/base_data_loader.py
@@ -8,7 +8,7 @@ class BaseDataLoader(DataLoader):
     """
     Base class for all data loaders
     """
-    def __init__(self, dataset, batch_size, shuffle, validation_split, n_cpu, collate_fn=default_collate):
+    def __init__(self, dataset, batch_size, shuffle, validation_split, num_workers, collate_fn=default_collate):
         self.validation_split = validation_split
         self.shuffle = shuffle
         
@@ -22,7 +22,7 @@ class BaseDataLoader(DataLoader):
             'batch_size': batch_size,
             'shuffle': self.shuffle,
             'collate_fn': collate_fn,
-            'num_workers': n_cpu
+            'num_workers': num_workers
             }
         super(BaseDataLoader, self).__init__(sampler=self.sampler, **self.init_kwargs)
 

--- a/base/base_data_loader.py
+++ b/base/base_data_loader.py
@@ -8,7 +8,7 @@ class BaseDataLoader(DataLoader):
     """
     Base class for all data loaders
     """
-    def __init__(self, dataset, batch_size, shuffle, validation_split, collate_fn=default_collate):
+    def __init__(self, dataset, batch_size, shuffle, validation_split, n_cpu, collate_fn=default_collate):
         self.validation_split = validation_split
         self.shuffle = shuffle
         
@@ -21,7 +21,8 @@ class BaseDataLoader(DataLoader):
             'dataset': dataset,
             'batch_size': batch_size,
             'shuffle': self.shuffle,
-            'collate_fn': collate_fn
+            'collate_fn': collate_fn,
+            'num_workers': n_cpu
             }
         super(BaseDataLoader, self).__init__(sampler=self.sampler, **self.init_kwargs)
 

--- a/config.json
+++ b/config.json
@@ -11,7 +11,8 @@
         "type": "MnistDataLoader",
         "args":{
             "data_dir": "data/",
-            "batch_size": 64,
+            "n_cpu": 2,
+            "batch_size": 128,
             "shuffle": true,
             "validation_split": 0.1
         }

--- a/config.json
+++ b/config.json
@@ -10,10 +10,10 @@
         "type": "MnistDataLoader",
         "args":{
             "data_dir": "data/",
-            "n_cpu": 2,
             "batch_size": 128,
             "shuffle": true,
-            "validation_split": 0.1
+            "validation_split": 0.1,
+            "num_workers": 2
         }
     },
     "optimizer": {

--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
     "name": "Mnist_LeNet",
-    "cuda": true,
-    "gpu": 0,
+    "n_gpu": 1,
     
     "arch": {
         "type": "MnistModel",

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -6,12 +6,12 @@ class MnistDataLoader(BaseDataLoader):
     """
     MNIST data loading demo using BaseDataLoader
     """
-    def __init__(self, data_dir, batch_size, shuffle, validation_split, training=True):
+    def __init__(self, data_dir, batch_size, shuffle, validation_split, n_cpu, training=True):
         trsfm = transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
             ])
         self.data_dir = data_dir
         self.dataset = datasets.MNIST(self.data_dir, train=training, download=True, transform=trsfm)
-        super(MnistDataLoader, self).__init__(self.dataset, batch_size, shuffle, validation_split)
+        super(MnistDataLoader, self).__init__(self.dataset, batch_size, shuffle, validation_split, n_cpu)
         

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -6,12 +6,12 @@ class MnistDataLoader(BaseDataLoader):
     """
     MNIST data loading demo using BaseDataLoader
     """
-    def __init__(self, data_dir, batch_size, shuffle, validation_split, n_cpu, training=True):
+    def __init__(self, data_dir, batch_size, shuffle, validation_split, num_workers, training=True):
         trsfm = transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
             ])
         self.data_dir = data_dir
         self.dataset = datasets.MNIST(self.data_dir, train=training, download=True, transform=trsfm)
-        super(MnistDataLoader, self).__init__(self.dataset, batch_size, shuffle, validation_split, n_cpu)
+        super(MnistDataLoader, self).__init__(self.dataset, batch_size, shuffle, validation_split, num_workers)
         

--- a/train.py
+++ b/train.py
@@ -45,29 +45,24 @@ def main(config, resume):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='PyTorch Template')
-
-    parser.add_argument('-f', '--force', action='store_true',
-                           help='ignore existing checkpoint and start training')
     parser.add_argument('-c', '--config', default=None, type=str,
                            help='config file path (default: None)')
     parser.add_argument('-r', '--resume', default=None, type=str,
                            help='path to latest checkpoint (default: None)')
     parser.add_argument('-d', '--device', default=None, type=str,
-                           help='specify indices of GPU to enable(default: all)')
-
+                           help='indices of GPUs to enable (default: all)')
     args = parser.parse_args()
 
     if args.config:
+        # load config file
         config = json.load(open(args.config))
         path = os.path.join(config['trainer']['save_dir'], config['name'])
-        if os.path.exists(path):
-            if not args.force:
-                msg = "Path {} already exists. Add '-f' or '--force' option to start training anyway, or change 'name' given in config file.".format(path)
-                raise AssertionError(msg)
     elif args.resume:
+        # load config file from checkpoint, in case new config file is not given.
+        # Use '--config' and '--resume' arguments together to load trained model and train more with changed config.
         config = torch.load(args.resume)['config']
     else:
-        raise AssertionError("Specify configuration file. By adding '-c config.json' for example.")
+        raise AssertionError("Configuration file need to be specified. Add '-c config.json', for example.")
     
     if args.device:
         os.environ["CUDA_VISIBLE_DEVICES"]=args.device

--- a/train.py
+++ b/train.py
@@ -52,6 +52,8 @@ if __name__ == '__main__':
                            help='config file path (default: None)')
     parser.add_argument('-r', '--resume', default=None, type=str,
                            help='path to latest checkpoint (default: None)')
+    parser.add_argument('-d', '--device', default=None, type=str,
+                           help='specify indices of GPU to enable(default: all)')
 
     args = parser.parse_args()
 
@@ -66,5 +68,8 @@ if __name__ == '__main__':
         config = torch.load(args.resume)['config']
     else:
         raise AssertionError("Specify configuration file. By adding '-c config.json' for example.")
+    
+    if args.device:
+        os.environ["CUDA_VISIBLE_DEVICES"]=args.device
 
     main(config, args.resume)


### PR DESCRIPTION
This PR handles two multi processing.
The first is multi-CPU for data loading, and the second is using multi-GPU(data parallel).

`Multi-CPU` is simply done by adding `n_cpu` argument in the config file and pasing it as `num_workers` option of pytorch native `DataLoader`.

`Multi-GPU` can be controlled with `n_gpu`option in config file, which replaces the previous gpu index and cuda option. Training without gpu is still possible with `"n_gpu": 0`

Specifying the GPU indices to use is possible externally with the environmental variable `CUDA_VISIBLE_DEVICES=0,1`.
I considered adding GPU indices into config file instead of `num_GPU` option and setting that on the `train.py`, but that would save GPU indices to the checkpoint, which can be problematic when resuming.

Tested on 3 machines,
my laptop: pytorch 0.4.1, no GPU
server1: pytorch 0.4.1, 8 * Tesla K80, cuda 9.1
server2: pytorch 0.4.0, 4 * GTX 1080, cuda 9.0

It worked fine for all of conditions I have tested, but I heard that one of my friend saying that giving non-zero value to the `num_workers` option raised exception for her machine. **So, please tell me if anything goes wrong.**

I'll update the README file later