### PR TITLE
Add early_stop option, use print instead of summary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ Config files are in `.json` format:
     }
   },
   "trainer": {
-    "epochs": 1000,             // number of training epochs
+    "epochs": 100,              // number of training epochs
     "save_dir": "saved/",       // checkpoints are saved in save_dir/name
     "save_freq": 1,             // save checkpoints every save_freq epochs
     "verbosity": 2,             // 0: quiet, 1: per epoch, 2: full
     "monitor": "val_loss",      // evaluation metric for finding best model
     "monitor_mode": "min"       // "min" if monitor value the lower the better, otherwise "max". "off" to disable
+    "early_stop": 0	            // number of epochs to wait before early stop. set 0 to disable.
   },
   "visualization":{
     "tensorboardX": true,       // enable tensorboardX visualization support

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Config files are in `.json` format:
     "save_freq": 1,                    // save checkpoints every save_freq epochs
     "verbosity": 2,                    // 0: quiet, 1: per epoch, 2: full
   
-    "monitor_mode": "min val_loss"     // mode and metric for model performance monitoring. set 'off' to disable.
-    "early_stop": 10	                   // number of epochs to wait before early stop. set 0 to disable.
+    "monitor": "min val_loss"          // mode and metric for model performance monitoring. set 'off' to disable.
+    "early_stop": 10	                 // number of epochs to wait before early stop. set 0 to disable.
   
     "tensorboardX": true,              // enable tensorboardX visualization support
     "log_dir": "saved/runs"            // directory to save log files for visualization
@@ -206,7 +206,7 @@ Specify indices of available GPUs by cuda environmental variable.
     * Training process logging
     * Checkpoint saving
     * Checkpoint resuming
-    * Reconfigurable monitored value for saving current best, and early stop option.
+    * Reconfigurable performance monitoring for saving current best model, and early stop training.
       * If config `monitor` is set to `max val_accuracy`, which means then the trainer will save a checkpoint `model_best.pth` when `validation accuracy` of epoch replaces current `maximum`.
       * If config `early_stop` is set, training will be automatically terminated when model performance does not improve for given number of epochs. This feature can be turned off by passing 0 to the `early_stop` option, or just deleting the line of config.
 

--- a/README.md
+++ b/README.md
@@ -101,46 +101,45 @@ Config files are in `.json` format:
     }                
   },
   "data_loader": {
-    "type": "MnistDataLoader",  // selecting data loader
+    "type": "MnistDataLoader",         // selecting data loader
     "args":{
-      "data_dir": "data/",      // dataset path
-      "batch_size": 64,         // batch size
-      "shuffle": true,          // shuffle training data before splitting
-      "validation_split": 0.1   // validation data ratio
-      "num_workers": 2,         // number of cpu processes to be used for data loading
+      "data_dir": "data/",             // dataset path
+      "batch_size": 64,                // batch size
+      "shuffle": true,                 // shuffle training data before splitting
+      "validation_split": 0.1          // validation data ratio
+      "num_workers": 2,                // number of cpu processes to be used for data loading
     }
   },
   "optimizer": {
     "type": "Adam",
     "args":{
-      "lr": 0.001,              // learning rate
-      "weight_decay": 0,        // (optional) weight decay
+      "lr": 0.001,                     // learning rate
+      "weight_decay": 0,               // (optional) weight decay
       "amsgrad": true
     }
   },
-  "loss": "nll_loss",           // loss
+  "loss": "nll_loss",                  // loss
   "metrics": [
-    "my_metric", "my_metric2"   // list of metrics to evaluate
+    "my_metric", "my_metric2"          // list of metrics to evaluate
   ],                         
   "lr_scheduler": {
-    "type":"StepLR",            // learning rate scheduler
+    "type": "StepLR",                   // learning rate scheduler
     "args":{
-      "step_size":50,          
-      "gamma":0.1
+      "step_size": 50,          
+      "gamma": 0.1
     }
   },
   "trainer": {
-    "epochs": 100,              // number of training epochs
-    "save_dir": "saved/",       // checkpoints are saved in save_dir/name
-    "save_freq": 1,             // save checkpoints every save_freq epochs
-    "verbosity": 2,             // 0: quiet, 1: per epoch, 2: full
-    "monitor": "val_loss",      // evaluation metric for finding best model
-    "monitor_mode": "min"       // "min" if monitor value the lower the better, otherwise "max". "off" to disable
-    "early_stop": 0	            // number of epochs to wait before early stop. set 0 to disable.
-  },
-  "visualization":{
-    "tensorboardX": true,       // enable tensorboardX visualization support
-    "log_dir": "saved/runs"     // directory to save log files for visualization
+    "epochs": 100,                     // number of training epochs
+    "save_dir": "saved/",              // checkpoints are saved in save_dir/name
+    "save_freq": 1,                    // save checkpoints every save_freq epochs
+    "verbosity": 2,                    // 0: quiet, 1: per epoch, 2: full
+  
+    "monitor_mode": "min val_loss"     // mode and metric for model performance monitoring. set 'off' to disable.
+    "early_stop": 10	                   // number of epochs to wait before early stop. set 0 to disable.
+  
+    "tensorboardX": true,              // enable tensorboardX visualization support
+    "log_dir": "saved/runs"            // directory to save log files for visualization
   }
 }
 ```
@@ -207,8 +206,9 @@ Specify indices of available GPUs by cuda environmental variable.
     * Training process logging
     * Checkpoint saving
     * Checkpoint resuming
-    * Reconfigurable monitored value for saving current best
-      * Controlled by the configs `monitor` and `monitor_mode`, if `monitor_mode == 'min'` then the trainer will save a checkpoint `model_best.pth` when `monitor` is a current minimum
+    * Reconfigurable monitored value for saving current best, and early stop option.
+      * If config `monitor` is set to `max val_accuracy`, which means then the trainer will save a checkpoint `model_best.pth` when `validation accuracy` of epoch replaces current `maximum`.
+      * If config `early_stop` is set, training will be automatically terminated when model performance does not improve for given number of epochs. This feature can be turned off by passing 0 to the `early_stop` option, or just deleting the line of config.
 
 2. **Implementing abstract methods**
 
@@ -225,7 +225,7 @@ Specify indices of available GPUs by cuda environmental variable.
 
     `BaseModel` handles:
     * Inherited from `torch.nn.Module`
-    * `summary()`: Model summary
+    * `__str__`: Modify native `print` function to prints the number of trainable parameters.
 
 2. **Implementing abstract methods**
 
@@ -282,7 +282,7 @@ A copy of config file will be saved in the same folder.
     'logger': self.train_logger,
     'state_dict': self.model.state_dict(),
     'optimizer': self.optimizer.state_dict(),
-    'monitor_best': self.monitor_best,
+    'monitor_best': self.mnt_best,
     'config': self.config
   }
   ```

--- a/base/base_model.py
+++ b/base/base_model.py
@@ -27,3 +27,12 @@ class BaseModel(nn.Module):
         params = sum([np.prod(p.size()) for p in model_parameters])
         self.logger.info('Trainable parameters: {}'.format(params))
         self.logger.info(self)
+
+    def __str__(self):
+        """
+        Model prints with number of trainable parameters
+        """
+        model_parameters = filter(lambda p: p.requires_grad, self.parameters())
+        params = sum([np.prod(p.size()) for p in model_parameters])
+        return super(BaseModel, self).__str__() + '\nTrainable parameters: {}'.format(params)
+        # print(super(BaseModel, self))

--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -25,31 +25,33 @@ class BaseTrainer:
         self.loss = loss
         self.metrics = metrics
         self.optimizer = optimizer
-
-        self.epochs = config['trainer']['epochs']
-        self.save_freq = config['trainer']['save_freq']
-        self.verbosity = config['trainer']['verbosity']
-
         self.train_logger = train_logger
 
+        cfg_trainer = config['trainer']
+        self.epochs = cfg_trainer['epochs']
+        self.save_period = cfg_trainer['save_period']
+        self.verbosity = cfg_trainer['verbosity']
+        self.monitor = cfg_trainer.get('monitor', 'off')
+
         # configuration to monitor model performance and save best
-        self.monitor = config['trainer']['monitor']
-        self.monitor_mode = config['trainer']['monitor_mode']
+        if self.monitor == 'off':
+            self.mnt_mode = 'off'
+            self.mnt_best = 0
+        else:
+            self.mnt_mode, self.mnt_metric = self.monitor.split()
+            assert self.mnt_mode in ['min', 'max']
 
-        self.early_stop = config['trainer']['early_stop']
-        if self.early_stop <= 0 or self.early_stop == None:
-            self.early_stop = math.inf
-
-        assert self.monitor_mode in ['min', 'max', 'off']
-        self.monitor_best = math.inf if self.monitor_mode == 'min' else -math.inf
+            self.mnt_best = math.inf if self.mnt_mode == 'min' else -math.inf
+            self.early_stop = cfg_trainer.get('early_stop', math.inf)
+        
         self.start_epoch = 1
 
         # setup directory for checkpoint saving
         start_time = datetime.datetime.now().strftime('%m%d_%H%M%S')
-        self.checkpoint_dir = os.path.join(config['trainer']['save_dir'], config['name'], start_time)
+        self.checkpoint_dir = os.path.join(cfg_trainer['save_dir'], config['name'], start_time)
         # setup visualization writer instance
-        writer_dir = os.path.join(config['visualization']['log_dir'], config['name'], start_time)
-        self.writer = WriterTensorboardX(writer_dir, self.logger, config['visualization']['tensorboardX'])
+        writer_dir = os.path.join(cfg_trainer['log_dir'], config['name'], start_time)
+        self.writer = WriterTensorboardX(writer_dir, self.logger, cfg_trainer['tensorboardX'])
 
         # Save configuration file into checkpoint directory:
         ensure_dir(self.checkpoint_dir)
@@ -101,25 +103,31 @@ class BaseTrainer:
 
             # evaluate model performance according to configured metric, save best checkpoint as model_best
             best = False
-            if self.monitor_mode != 'off':
+            if self.mnt_mode != 'off':
                 try:
-                    if  (self.monitor_mode == 'min' and log[self.monitor] < self.monitor_best) or\
-                        (self.monitor_mode == 'max' and log[self.monitor] > self.monitor_best):
-                        self.monitor_best = log[self.monitor]
-                        not_improved_count = 0
-                        best = True
+                    # check whether model performance improved or not, according to specified metric(mnt_metric)
+                    improved = (self.mnt_mode == 'min' and log[self.mnt_metric] < self.mnt_best) or \
+                               (self.mnt_mode == 'max' and log[self.mnt_metric] > self.mnt_best)
                 except KeyError:
-                    self.logger.warning("Warning: Metric '{}' is not found. Model performance monitoring is disabled.".format(self.monitor))
-                    self.monitor_mode = 'off'
+                    self.logger.warning("Warning: Metric '{}' is not found. Model performance monitoring is disabled.".format(self.mnt_metric))
+                    self.mnt_mode = 'off'
+                    improved = False
                     not_improved_count = 0
 
-            if epoch % self.save_freq == 0:
+                if improved:
+                    self.mnt_best = log[self.mnt_metric]
+                    not_improved_count = 0
+                    best = True
+                else:
+                    not_improved_count += 1
+
+                if not_improved_count > self.early_stop:
+                    self.logger.info("Validation performance didn\'t improve for {} epochs. Training stops.".format(self.early_stop))
+                    break
+
+            if epoch % self.save_period == 0:
                 self._save_checkpoint(epoch, save_best=best)
             
-            if not_improved_count >= self.early_stop:
-                self.logger.info("Validation performance didn\'t improve for {} epochs. Training stops.".format(self.early_stop))
-                break
-            not_improved_count += 1
 
     def _train_epoch(self, epoch):
         """
@@ -144,7 +152,7 @@ class BaseTrainer:
             'logger': self.train_logger,
             'state_dict': self.model.state_dict(),
             'optimizer': self.optimizer.state_dict(),
-            'monitor_best': self.monitor_best,
+            'monitor_best': self.mnt_best,
             'config': self.config
         }
         filename = os.path.join(self.checkpoint_dir, 'checkpoint-epoch{}.pth'.format(epoch))
@@ -164,7 +172,7 @@ class BaseTrainer:
         self.logger.info("Loading checkpoint: {} ...".format(resume_path))
         checkpoint = torch.load(resume_path)
         self.start_epoch = checkpoint['epoch'] + 1
-        self.monitor_best = checkpoint['monitor_best']
+        self.mnt_best = checkpoint['monitor_best']
 
         # load architecture params from checkpoint.
         if checkpoint['config']['arch'] != self.config['arch']:

--- a/config.json
+++ b/config.json
@@ -29,8 +29,8 @@
         "my_metric", "my_metric2"
     ],
     "lr_scheduler": {
-        "type":"StepLR",
-        "args":{
+        "type": "StepLR",
+        "args": {
             "step_size": 50,
             "gamma": 0.1
         }
@@ -40,9 +40,10 @@
         "save_dir": "saved/",
         "save_freq": 1,
         "verbosity": 2,
+        
         "monitor": "val_loss",
         "monitor_mode": "min",
-        "early_stop": 0
+        "early_stop": 10
     },
     "visualization":{
         "tensorboardX": true,

--- a/config.json
+++ b/config.json
@@ -31,17 +31,18 @@
     "lr_scheduler": {
         "type":"StepLR",
         "args":{
-            "step_size":50,
-            "gamma":0.1
+            "step_size": 50,
+            "gamma": 0.1
         }
     },
     "trainer": {
-        "epochs": 1000,
+        "epochs": 100,
         "save_dir": "saved/",
         "save_freq": 1,
         "verbosity": 2,
         "monitor": "val_loss",
-        "monitor_mode": "min"
+        "monitor_mode": "min",
+        "early_stop": 0
     },
     "visualization":{
         "tensorboardX": true,

--- a/config.json
+++ b/config.json
@@ -38,14 +38,12 @@
     "trainer": {
         "epochs": 100,
         "save_dir": "saved/",
-        "save_freq": 1,
+        "save_period": 1,
         "verbosity": 2,
         
-        "monitor": "val_loss",
-        "monitor_mode": "min",
-        "early_stop": 10
-    },
-    "visualization":{
+        "monitor": "min val_loss",
+        "early_stop": 10,
+        
         "tensorboardX": true,
         "log_dir": "saved/runs"
     }

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/train.py
+++ b/train.py
@@ -22,8 +22,8 @@ def main(config, resume):
 
     # build model architecture
     model = get_instance(module_arch, 'arch', config)
-    model.summary()
-
+    print(model)
+    
     # get function handles of loss and metrics
     loss = getattr(module_loss, config['loss'])
     metrics = [getattr(module_metric, met) for met in config['metrics']]

--- a/train.py
+++ b/train.py
@@ -65,6 +65,6 @@ if __name__ == '__main__':
         raise AssertionError("Configuration file need to be specified. Add '-c config.json', for example.")
     
     if args.device:
-        os.environ["CUDA_VISIBLE_DEVICES"]=args.device
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.device
 
     main(config, args.resume)

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -1,6 +1,4 @@
-import os
 import importlib
-import warnings
 
 
 class WriterTensorboardX():
@@ -11,9 +9,9 @@ class WriterTensorboardX():
             try:
                 self.writer = importlib.import_module('tensorboardX').SummaryWriter(log_path)
             except ModuleNotFoundError:
-                message = """TensorboardX visualization is configured to use, but currently not installed on this machine. Please install the package by 'pip install tensorboardx' command or turn off the option in the 'config.json' file."""
-                warnings.warn(message, UserWarning)
-                logger.warn()
+                message = "Warning: TensorboardX visualization is configured to use, but currently not installed on this machine. " + \
+                          "Please install the package by 'pip install tensorboardx' command or turn off the option in the 'config.json' file."
+                logger.warning(message)
         self.step = 0
         self.mode = ''
 


### PR DESCRIPTION
1. `early_stop` is added as suggested in #32. This feature can be set in the `early_stop` option in `config.json`. 

2. BaseModel class now override `__str__` function, instead of defining additional `summary` method to make it printed with number of params. This change replace `model.summary()` with `print(model)` in the `train.py`, making it does not crash when user does not inherit `BaseModel` and use `nn.Module`.

3. Changing config file layout on `monitor` option. Previously monitor mode and metric is set with two distinct options like `"monitor_mode = "min", monitor_metric = "val_loss"`. The same option for current layout is `"monitor" = "min val_loss"` now.

