### PR TITLE
Script to make new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ PyTorch deep learning project made easy.
   ├── train.py - main script to start training
   ├── test.py - evaluation of trained model
   ├── config.json - config file
+  ├── new_project.py - initialize new project with template files
   │
   ├── base/ - abstract base classes
   │   ├── base_data_loader.py - abstract base class for data loaders
@@ -173,6 +174,12 @@ Specify indices of available GPUs by cuda environmental variable.
   ```
 
 ## Customization
+
+### Project initialization
+Use the `new_project.py` script to make your new project directory with template files.
+`python3 new_project.py ../NewProject` then a new project folder named 'NewProject' will be made.
+This script will filter out unneccessary files like cache, git files or readme file. 
+
 ### Data Loader
 * **Writing your own data loader**
 

--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -1,1 +1,0 @@
-from .data_loaders import *

--- a/data_loader/data_loaders.py
+++ b/data_loader/data_loaders.py
@@ -6,7 +6,7 @@ class MnistDataLoader(BaseDataLoader):
     """
     MNIST data loading demo using BaseDataLoader
     """
-    def __init__(self, data_dir, batch_size, shuffle, validation_split, num_workers, training=True):
+    def __init__(self, data_dir, batch_size, shuffle=True, validation_split=0.0, num_workers=1, training=True):
         trsfm = transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))

--- a/new_project.py
+++ b/new_project.py
@@ -9,5 +9,5 @@ from shutil import copytree, ignore_patterns
 assert len(sys.argv) == 2, 'Specify a name for the new project. Example: python3 new_project.py MyNewProject'
 project_name = Path(sys.argv[1])
 
-ignore = [".git", "data", "saved", "initialize_project.py", "LICENSE", ".flake8", "README.md", "__pycache__"]
+ignore = [".git", "data", "saved", "new_project.py", "LICENSE", ".flake8", "README.md", "__pycache__"]
 copytree('.', project_name, ignore=ignore_patterns(*ignore))

--- a/new_project.py
+++ b/new_project.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+from shutil import copytree, ignore_patterns
+
+
+# This script initializes new pytorch project with the template files.
+# Run `python3 new_project.py ../MyNewProject` then new project named 
+# MyNewProject will be made
+assert len(sys.argv) == 2, 'Specify a name for the new project. Example: python3 new_project.py MyNewProject'
+project_name = Path(sys.argv[1])
+
+ignore = [".git", "data", "saved", "initialize_project.py", "LICENSE", ".flake8", "README.md", "__pycache__"]
+copytree('.', project_name, ignore=ignore_patterns(*ignore))


### PR DESCRIPTION
Previously copying template files into a new project was done by cp command, but some items like README.md, pycache dirs, or .gitignore need to be added or deleted manually after that. With this `new_project.py` script, new project can be made in one command. 
example command is `python3 new_project.py ../NewProjectName`.
I will update README in few days.