### PR TITLE
Customizable CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ PyTorch deep learning project made easy.
 
 ## Features
 * Clear folder structure which is suitable for many deep learning projects.
-* `.json` config file support for more convenient parameter tuning.
+* `.json` config file support for convenient parameter tuning.
+* Customizable command line options for more convenient parameter tuning.
 * Checkpoint saving and resuming.
 * Abstract base classes for faster development:
   * `BaseTrainer` handles checkpoint saving/resuming, training process logging, and more.
@@ -54,15 +55,15 @@ PyTorch deep learning project made easy.
   ├── train.py - main script to start training
   ├── test.py - evaluation of trained model
   │
-  ├── config.json - config file
-  ├── parse_config.py - class to handle config file 
+  ├── config.json - holds configuration for training
+  ├── parse_config.py - class to handle config file and cli options
   │
   ├── new_project.py - initialize new project with template files
   │
   ├── base/ - abstract base classes
-  │   ├── base_data_loader.py - abstract base class for data loaders
-  │   ├── base_model.py - abstract base class for models
-  │   └── base_trainer.py - abstract base class for trainers
+  │   ├── base_data_loader.py
+  │   ├── base_model.py
+  │   └── base_trainer.py
   │
   ├── data_loader/ - anything about data loading goes here
   │   └── data_loaders.py
@@ -70,20 +71,24 @@ PyTorch deep learning project made easy.
   ├── data/ - default directory for storing input data
   │
   ├── model/ - models, losses, and metrics
-  │   ├── loss.py
+  │   ├── model.py
   │   ├── metric.py
-  │   └── model.py
+  │   └── loss.py
   │
   ├── saved/
   │   ├── models/ - trained models are saved here
-  │   └── log/ - default logdir for tensorboardX
+  │   └── log/ - default logdir for tensorboardX and logging output
   │
   ├── trainer/ - trainers
   │   └── trainer.py
   │
-  └── utils/
+  ├── logger/ - module for tensorboardX visualization and logging
+  │   ├── visualization.py
+  │   ├── logger.py
+  │   └── logger_config.json
+  │  
+  └── utils/ - small utility functions
       ├── util.py
-      ├── visualization.py - class for tensorboardX visualization support
       └── ...
   ```
 
@@ -181,6 +186,29 @@ Specify indices of available GPUs by cuda environmental variable.
 Use the `new_project.py` script to make your new project directory with template files.
 `python3 new_project.py ../NewProject` then a new project folder named 'NewProject' will be made.
 This script will filter out unneccessary files like cache, git files or readme file. 
+
+### Adding custom CLI options
+
+Changing values of config file is a clean, safe and easy way of tuning hyperparameters. However, sometimes
+it is better to have command line options if some values need to be changed too often or quickly.
+
+This template uses the configurations stored in the json file by default, but by registering custom options as follows
+you can change some of them using CLI flags.
+
+```python
+# simple class-like object having 3 attributes, `flags`, `type`, `target`.
+CustomArgs = collections.namedtuple('CustomArgs', 'flags type target')
+options = [
+    CustomArgs(['--lr', '--learning_rate'], type=float, target=('optimizer', 'args', 'lr')),
+    CustomArgs(['--bs', '--batch_size'], type=int, target=('data_loader', 'args', 'batch_size'))
+    # options added here can be modified by command line flags.
+]
+```
+`target` here is a sequence of keys which are required to access that option in the config dict.
+In this example, `target` of learning rate option is `('optimizer', 'args', 'lr')` because `config['optimizer']['args']['lr']` points to the learning rate.
+`python3 train.py -c config.json --bs 256` runs training with options given in `config.json` except for the `batch size`
+which is increased to 256 by command line options.
+
 
 ### Data Loader
 * **Writing your own data loader**

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ PyTorch deep learning project made easy.
 		* [Resuming from checkpoints](#resuming-from-checkpoints)
     * [Using Multiple GPU](#using-multiple-gpu)
 	* [Customization](#customization)
+		* [Custom CLI options](#custom-cli-options)
 		* [Data Loader](#data-loader)
 		* [Trainer](#trainer)
 		* [Model](#model)
@@ -94,7 +95,7 @@ PyTorch deep learning project made easy.
 
 ## Usage
 The code in this repo is an MNIST example of the template.
-Try `python3 train.py -c config.json` to run code.
+Try `python train.py -c config.json` to run code.
 
 ### Config file format
 Config files are in `.json` format:
@@ -184,10 +185,10 @@ Specify indices of available GPUs by cuda environmental variable.
 
 ### Project initialization
 Use the `new_project.py` script to make your new project directory with template files.
-`python3 new_project.py ../NewProject` then a new project folder named 'NewProject' will be made.
+`python new_project.py ../NewProject` then a new project folder named 'NewProject' will be made.
 This script will filter out unneccessary files like cache, git files or readme file. 
 
-### Adding custom CLI options
+### Custom CLI options
 
 Changing values of config file is a clean, safe and easy way of tuning hyperparameters. However, sometimes
 it is better to have command line options if some values need to be changed too often or quickly.
@@ -195,18 +196,18 @@ it is better to have command line options if some values need to be changed too 
 This template uses the configurations stored in the json file by default, but by registering custom options as follows
 you can change some of them using CLI flags.
 
-```python
-# simple class-like object having 3 attributes, `flags`, `type`, `target`.
-CustomArgs = collections.namedtuple('CustomArgs', 'flags type target')
-options = [
-    CustomArgs(['--lr', '--learning_rate'], type=float, target=('optimizer', 'args', 'lr')),
-    CustomArgs(['--bs', '--batch_size'], type=int, target=('data_loader', 'args', 'batch_size'))
-    # options added here can be modified by command line flags.
-]
-```
-`target` here is a sequence of keys which are required to access that option in the config dict.
-In this example, `target` of learning rate option is `('optimizer', 'args', 'lr')` because `config['optimizer']['args']['lr']` points to the learning rate.
-`python3 train.py -c config.json --bs 256` runs training with options given in `config.json` except for the `batch size`
+  ```python
+  # simple class-like object having 3 attributes, `flags`, `type`, `target`.
+  CustomArgs = collections.namedtuple('CustomArgs', 'flags type target')
+  options = [
+      CustomArgs(['--lr', '--learning_rate'], type=float, target=('optimizer', 'args', 'lr')),
+      CustomArgs(['--bs', '--batch_size'], type=int, target=('data_loader', 'args', 'batch_size'))
+      # options added here can be modified by command line flags.
+  ]
+  ```
+`target` argument should be sequence of keys, which are used to access that option in the config dict. In this example, `target` 
+for the learning rate option is `('optimizer', 'args', 'lr')` because `config['optimizer']['args']['lr']` points to the learning rate.
+`python train.py -c config.json --bs 256` runs training with options given in `config.json` except for the `batch size`
 which is increased to 256 by command line options.
 
 

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from utils import read_json
 
 
-def setup_logging(save_dir, log_config='utils/logger_config.json', default_level=logging.INFO):
+def setup_logging(save_dir, log_config='logger/logger_config.json', default_level=logging.INFO):
     """
     Setup logging configuration
     """
@@ -18,4 +18,5 @@ def setup_logging(save_dir, log_config='utils/logger_config.json', default_level
 
         logging.config.dictConfig(config)
     else:
+        print("Warning: logging configuration file is not found in {}.".format(log_config))
         logging.basicConfig(level=default_level)

--- a/logger/visualization.py
+++ b/logger/visualization.py
@@ -1,4 +1,5 @@
 import importlib
+from utils import Timer
 
 
 class WriterTensorboardX():
@@ -21,11 +22,16 @@ class WriterTensorboardX():
             'add_text', 'add_histogram', 'add_pr_curve', 'add_embedding'
         ]
         self.tag_mode_exceptions = ['add_histogram', 'add_embedding']
-
+        self.timer = Timer()
 
     def set_step(self, step, mode='train'):
         self.mode = mode
         self.step = step
+        if step == 0:
+            self.timer.reset()
+        else:
+            duration = self.timer.check()
+            self.add_scalar('steps_per_sec', 1 / duration)
 
     def __getattr__(self, name):
         """
@@ -41,7 +47,7 @@ class WriterTensorboardX():
                 if add_data is not None:
                     # add mode(train/valid) tag
                     if name not in self.tag_mode_exceptions:
-                        tag = '{}/{}'.format(self.mode, tag)
+                        tag = '{}/{}'.format(tag, self.mode)
                     add_data(tag, data, self.step, *args, **kwargs)
             return wrapper
         else:

--- a/parse_config.py
+++ b/parse_config.py
@@ -1,40 +1,48 @@
 import os
 import logging
 from pathlib import Path
-from shutil import copyfile
+from functools import reduce
+from operator import getitem
 from datetime import datetime
 from logger import setup_logging
-from utils import read_json
+from utils import read_json, write_json
 
 
 class ConfigParser:
-    def __init__(self, args):
+    def __init__(self, args, options=None):
+        # parse default and custom cli options
+        for opt in options:
+            args.add_argument(*opt.flags, default=None, type=opt.type)
         args = args.parse_args()
+
         if args.device:
             os.environ["CUDA_VISIBLE_DEVICES"] = args.device
         if args.resume:
             self.resume = Path(args.resume)
             self.cfg_fname = self.resume.parent / 'config.json'
         else:
+            msg_no_cfg = "Configuration file need to be specified. Add '-c config.json', for example."
+            assert args.config is not None, msg_no_cfg
             self.resume = None
             self.cfg_fname = Path(args.config)
-        assert self.cfg_fname is not None, "Configuration file need to be specified. Add '-c config.json', for example."
-        
-        self.config = read_json(self.cfg_fname)
-        self.exper_name = self.config['name']
+
+        # load config file and apply custom cli options
+        config = read_json(self.cfg_fname)
+        self.config = _update_config(config, options, args)
 
         # set save_dir where trained model and log will be saved.
         save_dir = Path(self.config['trainer']['save_dir'])
-        timestamp = datetime.now().strftime('%m%d_%H%M%S')# if timestamp else ''
+        timestamp = datetime.now().strftime(r'%m%d_%H%M%S')# if timestamp else ''
 
-        self.save_dir = save_dir / 'models' / self.exper_name / timestamp
-        self.log_dir = save_dir / 'log' / self.exper_name / timestamp
+        exper_name = self.config['name']
+        self.save_dir = save_dir / 'models' / exper_name / timestamp
+        self.log_dir = save_dir / 'log' / exper_name / timestamp
 
         self.save_dir.mkdir(parents=True)
         self.log_dir.mkdir(parents=True)
 
-        # copy the config file to the checkpoint dir # NOTE: str() can be removed from here on python 3.6 
-        copyfile(str(self.cfg_fname), str(self.save_dir / 'config.json'))
+        # save updated config file to the checkpoint dir
+        write_json(self.config, self.save_dir / 'config.json')
 
         # configure logging module
         setup_logging(self.log_dir)
@@ -56,7 +64,30 @@ class ConfigParser:
         return self.config[name]
 
     def get_logger(self, name, verbosity=2):
+        msg_verbosity = 'verbosity option {} is invalid. Valid options are {}.'.format(verbosity, self.log_levels.keys())
+        assert verbosity in self.log_levels, msg_verbosity
         logger = logging.getLogger(name)
-        assert verbosity in self.log_levels, 'verbosity option {} is invalid. Valid options are {}.'.format(verbosity, self.log_levels.keys())
         logger.setLevel(self.log_levels[verbosity])
         return logger
+
+# helper functions used to update config dict with custom cli options
+def _update_config(config, options, args):
+    for opt in options:
+        value = getattr(args, _get_opt_name(opt.flags))
+        if value is not None:
+            _set_by_path(config, opt.target, value)
+    return config
+
+def _get_opt_name(flags):
+    for flg in flags:
+        if flg.startswith('--'):
+            return flg.replace('--', '')
+    return flags[0].replace('--', '')
+
+def _set_by_path(tree, keys, value):
+    """Set a value in a nested object in tree by sequence of keys."""
+    _get_by_path(tree, keys[:-1])[keys[-1]] = value
+
+def _get_by_path(tree, keys):
+    """Access a nested object in tree by sequence of keys."""
+    return reduce(getitem, keys, tree)

--- a/train.py
+++ b/train.py
@@ -1,4 +1,5 @@
 import argparse
+import collections
 import torch
 import data_loader.data_loaders as module_data
 import model.loss as module_loss
@@ -47,5 +48,11 @@ if __name__ == '__main__':
     args.add_argument('-d', '--device', default=None, type=str,
                         help='indices of GPUs to enable (default: all)')
 
-    config = ConfigParser(args)
+    # custom cli options to modify configuration from default values given in json file.
+    CustomArgs = collections.namedtuple('CustomArgs', 'flags type target')
+    options = [
+        CustomArgs(['--lr', '--learning_rate'], type=float, target=('optimizer', 'args', 'lr')),
+        CustomArgs(['--bs', '--batch_size'], type=int, target=('data_loader', 'args', 'batch_size'))
+    ]
+    config = ConfigParser(args, options)
     main(config)

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,7 +1,5 @@
 import json
-import time
 from pathlib import Path
-from datetime import datetime
 from collections import OrderedDict
 
 
@@ -17,30 +15,3 @@ def read_json(fname):
 def write_json(content, fname):
     with fname.open('wt') as handle:
         json.dump(content, handle, indent=4, sort_keys=False)
-
-
-class Timer:
-    def __init__(self):
-        self.cache = None
-        self.recording = False
-
-    def tic(self):
-        self.recording = True
-        self.cache = datetime.now()
-
-    def toc(self):
-        assert self.recording, 'start timer by calling timer.tic() first.'
-        self.recording = False
-        return datetime.now() - self.cache
-
-
-if __name__ == '__main__':
-    timer = Timer()
-    a = 0
-    for i in range(3):
-
-        timer.tic()
-        time.sleep(1)
-        # record = float(timer.toc())
-        print(timer.toc())
-        print(timer.toc())

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,5 +1,7 @@
 import json
+import time
 from pathlib import Path
+from datetime import datetime
 from collections import OrderedDict
 
 
@@ -15,3 +17,30 @@ def read_json(fname):
 def write_json(content, fname):
     with fname.open('wt') as handle:
         json.dump(content, handle, indent=4, sort_keys=False)
+
+
+class Timer:
+    def __init__(self):
+        self.cache = None
+        self.recording = False
+
+    def tic(self):
+        self.recording = True
+        self.cache = datetime.now()
+
+    def toc(self):
+        assert self.recording, 'start timer by calling timer.tic() first.'
+        self.recording = False
+        return datetime.now() - self.cache
+
+
+if __name__ == '__main__':
+    timer = Timer()
+    a = 0
+    for i in range(3):
+
+        timer.tic()
+        time.sleep(1)
+        # record = float(timer.toc())
+        print(timer.toc())
+        print(timer.toc())

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from datetime import datetime
 from collections import OrderedDict
 
 
@@ -15,3 +16,16 @@ def read_json(fname):
 def write_json(content, fname):
     with fname.open('wt') as handle:
         json.dump(content, handle, indent=4, sort_keys=False)
+
+class Timer:
+    def __init__(self):
+        self.cache = datetime.now()
+
+    def check(self):
+        now = datetime.now()
+        duration = now - self.cache
+        self.cache = now
+        return duration.total_seconds()
+
+    def reset(self):
+        self.cache = datetime.now()


### PR DESCRIPTION
This PR contains a new feature: configurable CLI options.
Following is an example of adding two flags with this, which is included in `train.py`. 

```python
# simple class-like object having 3 attributes, `flags`, `type`, `target`.
CustomArgs = collections.namedtuple('CustomArgs', 'flags type target')
options = [
    CustomArgs(['--lr', '--learning_rate'], type=float, target=('optimizer', 'args', 'lr')),
    CustomArgs(['--bs', '--batch_size'], type=int, target=('data_loader', 'args', 'batch_size'))
    # options added here can be modified by command line flags.
]
```
`target` here is a sequence of keys which are required to access that option in the config dict.
In this example, `target` of learning rate option is `('optimizer', 'args', 'lr')` because `config['optimizer']['args']['lr']` points to the learning rate.
`python3 train.py -c config.json --bs 256` runs training with options given in `config.json` except for the `batch size` which is increased to 256 by command line options.
