### PR TITLE
add iteration-based training

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PyTorch deep learning project made easy.
 <!-- /code_chunk_output -->
 
 ## Requirements
-* Python >= 3.5
+* Python >= 3.5 (3.6 recommended)
 * PyTorch >= 0.4
 * tqdm (Optional for `test.py`)
 * tensorboard >= 1.7.0 (Optional for TensorboardX)
@@ -256,6 +256,10 @@ which is increased to 256 by command line options.
 
   Please refer to `trainer/trainer.py` for MNIST training.
 
+* **Iteration-based training**
+
+  `Trainer.__init__` takes an optional argument, `len_epoch` which controls number of batches(steps) in each epoch.
+
 ### Model
 * **Writing your own model**
 
@@ -289,7 +293,7 @@ If you have additional information to be logged, in `_train_epoch()` of your tra
 
   ```python
   additional_log = {"gradient_norm": g, "sensitivity": s}
-  log = {**log, **additional_log}
+  log = log.update(additional_log)
   return log
   ```
   
@@ -353,17 +357,17 @@ Feel free to contribute any kind of function or enhancement, here the coding sty
 Code should pass the [Flake8](http://flake8.pycqa.org/en/latest/) check before committing.
 
 ## TODOs
-- [ ] Iteration-based training (instead of epoch-based)
+
+- [ ] Using fixed random seed
+- [ ] Check pytorch 1.1
 - [ ] Multiple optimizers
-- [ ] Configurable logging layout, checkpoint naming
-- [ ] `visdom` logger support
+- [ ] Support pytorch native tensorboard
+- [ ] Support more tensorboard functions
 - [x] `tensorboardX` logger support
+- [x] Configurable logging layout, checkpoint naming
+- [x] Iteration-based training (instead of epoch-based)
 - [x] Adding command line option for fine-tuning
 - [x] Multi-GPU support
-- [x] Update the example to PyTorch 0.4
-- [x] Learning rate scheduler
-- [x] Deprecate `BaseDataLoader`, use `torch.utils.data` instesad
-- [x] Load settings from `config` files
 
 ## License
 This project is licensed under the MIT License. See  LICENSE for more details

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from datetime import datetime
+from itertools import repeat
 from collections import OrderedDict
 
 
@@ -17,6 +18,14 @@ def write_json(content, fname):
     with fname.open('wt') as handle:
         json.dump(content, handle, indent=4, sort_keys=False)
 
+def inf_loop(data_loader):
+    '''
+    wrapper function to make pytorch data loader loops endlessly.
+    '''
+    for loader in repeat(data_loader):
+        for data, target in loader:
+            yield data, target
+
 class Timer:
     def __init__(self):
         self.cache = datetime.now()
@@ -29,3 +38,4 @@ class Timer:
 
     def reset(self):
         self.cache = datetime.now()
+

--- a/utils/util.py
+++ b/utils/util.py
@@ -19,12 +19,9 @@ def write_json(content, fname):
         json.dump(content, handle, indent=4, sort_keys=False)
 
 def inf_loop(data_loader):
-    '''
-    wrapper function to make pytorch data loader loops endlessly.
-    '''
+    ''' wrapper function for endless data loader. '''
     for loader in repeat(data_loader):
-        for data, target in loader:
-            yield data, target
+        yield from loader
 
 class Timer:
     def __init__(self):
@@ -38,4 +35,3 @@ class Timer:
 
     def reset(self):
         self.cache = datetime.now()
-


### PR DESCRIPTION
Implementation of iteration-based training, requested in issue #50.
`trainer` instance now take an argument `len_epoch`, which determines the number of steps(batches) in each epoch.

Following is utility function to repeat pytorch `data_loader` to loop it endlessly.

```
def inf_loop(data_loader):
    '''
    wrapper function to make pytorch data loader loops endlessly.
    '''
    for loader in repeat(data_loader):
        for data, target in loader:
            yield data, target
```