### PR TITLE
Fix checkpoint resuming

### DIFF
--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -61,6 +61,7 @@ class BaseTrainer:
         """
         Full training logic
         """
+        not_improved_count = 0
         for epoch in range(self.start_epoch, self.epochs + 1):
             result = self._train_epoch(epoch)
 
@@ -90,7 +91,6 @@ class BaseTrainer:
                                         "Model performance monitoring is disabled.".format(self.mnt_metric))
                     self.mnt_mode = 'off'
                     improved = False
-                    not_improved_count = 0
 
                 if improved:
                     self.mnt_best = log[self.mnt_metric]

--- a/parse_config.py
+++ b/parse_config.py
@@ -17,17 +17,20 @@ class ConfigParser:
 
         if args.device:
             os.environ["CUDA_VISIBLE_DEVICES"] = args.device
-        if args.resume:
-            self.resume = Path(args.resume)
-            self.cfg_fname = self.resume.parent / 'config.json'
-        else:
+        if args.resume is None:
             msg_no_cfg = "Configuration file need to be specified. Add '-c config.json', for example."
             assert args.config is not None, msg_no_cfg
-            self.resume = None
             self.cfg_fname = Path(args.config)
+            config = read_json(self.cfg_fname)
+            self.resume = None
+        else:        
+            self.resume = Path(args.resume)
+            resume_cfg_fname = self.resume.parent / 'config.json'
+            config = read_json(resume_cfg_fname)
+            if args.config is not None:
+                config.update(read_json(Path(args.config)))
 
         # load config file and apply custom cli options
-        config = read_json(self.cfg_fname)
         self._config = _update_config(config, options, args)
 
         # set save_dir where trained model and log will be saved.


### PR DESCRIPTION
fix issues reported in #57 
1. reference before assignment error
2. invalid sanity check

Fixing the first was much easier than I thought it to be.
Moving line 93 up to the line 64 solved the problem.

For the second, the sanity check was there for fine-tuning condition, where a trained checkpoint is loaded and updated by new `config.json` file given by CLI argument. I noticed that new config file was simply being ignored, and made them work correctly.