### PR TITLE
Minor fixes to `Trainer` and `BaseTrainer` Initializers

### DIFF
--- a/base/base_trainer.py
+++ b/base/base_trainer.py
@@ -8,13 +8,12 @@ class BaseTrainer:
     """
     Base class for all trainers
     """
-    def __init__(self, model, criterion, metric_ftns, optimizer, config):
+    def __init__(self, model, criterion, optimizer, config):
         self.config = config
         self.logger = config.get_logger('trainer', config['trainer']['verbosity'])
 
         self.model = model
         self.criterion = criterion
-        self.metric_ftns = metric_ftns
         self.optimizer = optimizer
 
         cfg_trainer = config['trainer']

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -11,8 +11,8 @@ class Trainer(BaseTrainer):
     """
     def __init__(self, model, criterion, metric_ftns, optimizer, config, device,
                  data_loader, valid_data_loader=None, lr_scheduler=None, len_epoch=None):
-        super().__init__(model, criterion, metric_ftns, optimizer, config)
-        self.config = config
+        super().__init__(model, criterion, optimizer, config)
+        self.metric_ftns = metric_ftns
         self.device = device
         self.data_loader = data_loader
         if len_epoch is None:


### PR DESCRIPTION
- `self.metric_ftns` was previously assigned in `BaseTrainer.__init__`, but there are no uses of `self.metric_ftns` in BaseTrainer. What's more, it seems that tracking metrics is not a responsibility of BaseTrainer. Thus, this has been removed from BaseTrainer and `self.metric_ftns` is now assigned in `Trainer.__init__`.
- `self.config` was previously assigned in both `BaseTrainer.__init__` and `Trainer.__init__`. It has been removed from `Trainer`.