### PR TITLE
Support `in` operation in ConfigParser

### DIFF
--- a/parse_config.py
+++ b/parse_config.py
@@ -111,6 +111,10 @@ class ConfigParser:
         """Access items like ordinary dict."""
         return self.config[name]
 
+    def __contains__(self, name):
+        """Use in operation like ordinary dict."""
+        return name in self.config
+
     def get_logger(self, name, verbosity=2):
         msg_verbosity = 'verbosity option {} is invalid. Valid options are {}.'.format(verbosity, self.log_levels.keys())
         assert verbosity in self.log_levels, msg_verbosity


### PR DESCRIPTION
Sometimes it is necessary to judge whether the object of `ConfigParser` contains a specific `key` during my developing. According to the overloading of `__getitem__` operation, I add a overloading of `__contains__` for fixing the fallback error when using `in` operation.